### PR TITLE
🐛fix(select-field): fix default selectField parseValue

### DIFF
--- a/packages/oak/lib/fields.js
+++ b/packages/oak/lib/fields.js
@@ -29,7 +29,7 @@ export const FIELD_SELECT = {
       placeholder={<Text>{ field.placeholder }</Text>}
       parseTitle={field.parseTitle ||
         (o => o?.title ? <Text>{ o.title }</Text> : o)}
-      parseValue={field.parseValue || (o => o?.value || o)}
+      parseValue={field.parseValue || (o => o?.value ?? o)}
     />
   ),
 };


### PR DESCRIPTION
Fix the default selectField parseValue, to be usable with boolean value type