### PR TITLE
🐛fix(get-text): fix get text with non string value

### DIFF
--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -371,8 +371,11 @@ export default forwardRef((options, ref) => {
     }
   };
 
-  const getText = (key, def) =>
-    get(state.texts, key, def);
+  const getText = (key, def) => {
+    if (typeof key !== 'string') return def;
+
+    return get(state.texts, key, def);
+  };
 
   const setTexts = texts =>
     dispatch({ texts });


### PR DESCRIPTION
fix the get Text function for non string values