### PR TITLE
🐛fix(image-component): show add touchable zone if upload fails

### DIFF
--- a/packages/oak-addon-basic-components/lib/core/ImageField/index.js
+++ b/packages/oak-addon-basic-components/lib/core/ImageField/index.js
@@ -52,7 +52,12 @@ export default ({
 
     if (events?.onImageUpload) {
       const result = await events.onImageUpload(event);
-      onUrlReady(result);
+
+      if (result) {
+        onUrlReady(result);
+      } else {
+        dispatch({ loading: false });
+      }
     } else {
       const file = e.target.files[0];
 


### PR DESCRIPTION
If an upload fails, it will show the touchable zone again to allow user to try again. 