### PR TITLE
🐛fix(alignments): fix horizontal alignement - DASHV6-205

### DIFF
--- a/packages/oak/lib/core/Row/index.styl
+++ b/packages/oak/lib/core/Row/index.styl
@@ -80,21 +80,20 @@
     margin: -($half-gutter)
     width: unquote("calc(100% + ") $gutters unquote(")")
 
-    for i in (flex-start center flex-end)
-      $direction = replace(flex-, '', i)
+    for alignment in (flex-start center flex-end space-between space-around)
 
       &.oak-align
-        &-{$direction}
-          align-items: i
+        &-{alignment}
+          align-items: alignment
 
       &.oak-justify
-        &-{$direction}
-          justify-content: i
+        &-{alignment}
+          justify-content: alignment
 
-    for i in (row row-reverse column column-reverse)
+    for direction  in (row row-reverse column column-reverse)
       &.oak-direction
-        &-{i}
-          flex-direction: i
+        &-{direction}
+          flex-direction: direction
 
     > .oak-col
       padding: $half-gutter

--- a/packages/oak/lib/core/Row/index.styl
+++ b/packages/oak/lib/core/Row/index.styl
@@ -90,7 +90,7 @@
         &-{alignment}
           justify-content: alignment
 
-    for direction  in (row row-reverse column column-reverse)
+    for direction in (row row-reverse column column-reverse)
       &.oak-direction
         &-{direction}
           flex-direction: direction


### PR DESCRIPTION
Before the generated classes were `oak-justify-flex-start` but css wanted a className like `oak-justify-start` to apply styles.
 I simply added -flex- for css classname catching.
In addition, I added `space-around` and `space-between` that were not catched too. 

https://user-images.githubusercontent.com/10706836/126294055-133e6a85-8818-49a8-bed8-602e657217d6.mov

