### PR TITLE
🐛fix: oak text editor font size - DASHV6-226

### DIFF
--- a/packages/oak-addon-basic-components/lib/core/Editor/BlockButton.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/BlockButton.js
@@ -1,9 +1,10 @@
 import { useSlate } from 'slate-react';
 import { classNames } from '@poool/junipero-utils';
+import { Tooltip } from '@poool/junipero';
 
 import { isBlockActive, toggleBlock } from './editor';
 
-export default ({ format, icon, className }) => {
+export default ({ format, icon, className, tooltipText }) => {
   const editor = useSlate();
 
   const onClick = e => {
@@ -12,19 +13,21 @@ export default ({ format, icon, className }) => {
   };
 
   return (
-    <a
-      href="#"
-      onClick={onClick}
-      className={classNames(
-        'oak-toolbar-button',
-        'oak-' + format,
-        {
-          'oak-active': isBlockActive(editor, format),
-        },
-        className,
-      )}
-    >
-      <i className="oak-icons">{ icon }</i>
-    </a>
+    <Tooltip text={tooltipText}>
+      <a
+        href="#"
+        onClick={onClick}
+        className={classNames(
+          'oak-toolbar-button',
+          'oak-' + format,
+          {
+            'oak-active': isBlockActive(editor, format),
+          },
+          className,
+        )}
+      >
+        <i className="oak-icons">{ icon }</i>
+      </a>
+    </Tooltip>
   );
 };

--- a/packages/oak-addon-basic-components/lib/core/Editor/BlockButton.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/BlockButton.js
@@ -1,6 +1,5 @@
 import { useSlate } from 'slate-react';
-import { classNames } from '@poool/junipero-utils';
-import { Tooltip } from '@poool/junipero';
+import { Tooltip, classNames } from '@poool/junipero';
 
 import { isBlockActive, toggleBlock } from './editor';
 

--- a/packages/oak-addon-basic-components/lib/core/Editor/ColorButton.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/ColorButton.js
@@ -58,9 +58,10 @@ export default ({ className }) => {
     <Dropdown className="oak-color-field">
       <DropdownToggle tag="span">
         <Tooltip text={(
-          <Text>{t => t('addons.basicComponents.fields.editor.color',
-            'Color')}
-          </Text>
+          <Text
+            name="addons.basicComponents.fields.editor.color"
+            default="Color"
+          />
         )}
         >
           <a

--- a/packages/oak-addon-basic-components/lib/core/Editor/ColorButton.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/ColorButton.js
@@ -9,6 +9,7 @@ import {
   Tooltip,
 } from '@poool/junipero';
 import { classNames } from '@poool/junipero-utils';
+import { Text } from '@poool/oak';
 
 import { toggleMark } from './editor';
 
@@ -56,7 +57,12 @@ export default ({ className }) => {
   return (
     <Dropdown className="oak-color-field">
       <DropdownToggle tag="span">
-        <Tooltip text="Color">
+        <Tooltip text={(
+          <Text>{t => t('addons.basicComponents.fields.editor.color',
+            'Color')}
+          </Text>
+        )}
+        >
           <a
             href="#"
             onClick={onClick}

--- a/packages/oak-addon-basic-components/lib/core/Editor/index.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/index.js
@@ -100,27 +100,30 @@ export default ({
             format="bold"
             icon="format_bold"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.bold',
-                'Bold')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.bold"
+                default="Bold"
+              />
             )}
           />
           <MarkButton
             format="italic"
             icon="format_italic"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.italic',
-                'Italic')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.italic"
+                default="Italic"
+              />
             )}
           />
           <MarkButton
             format="underline"
             icon="format_underlined"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.underline',
-                'Underline')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.underline"
+                default="Underline"
+              />
             )}
           />
           <ColorButton />
@@ -129,9 +132,10 @@ export default ({
             increase={false}
             currentSize={getTextSize()}
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.decrease',
-                'Decrease size')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.decrease"
+                default="Decrease size"
+              />
             )}
           />
           <span className="oak-text-size">{ getTextSize() }</span>
@@ -139,45 +143,50 @@ export default ({
             icon="add"
             currentSize={getTextSize()}
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.increase',
-                'Increase size')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.increase"
+                default="Increase size"
+              />
             )}
           />
           <BlockButton
             format="text-left"
             icon="format_align_left"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.left',
-                'Align left')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.left"
+                default="Align left"
+              />
             )}
           />
           <BlockButton
             format="text-center"
             icon="format_align_center"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.center',
-                'Align center')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.center"
+                default="Align center"
+              />
             )}
           />
           <BlockButton
             format="text-right"
             icon="format_align_right"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.right',
-                'Align right')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.right"
+                default="Align right"
+              />
             )}
           />
           <BlockButton
             format="text-justify"
             icon="format_align_justify"
             tooltipText={(
-              <Text>{t => t('addons.basicComponents.fields.editor.justify',
-                'Justify')}
-              </Text>
+              <Text
+                name="addons.basicComponents.fields.editor.justify"
+                default="Justify"
+              />
             )}
           />
         </div>

--- a/packages/oak-addon-basic-components/lib/core/Editor/index.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/index.js
@@ -4,6 +4,7 @@ import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
 import { Editable, Slate, withReact } from 'slate-react';
 import isHotkey from 'is-hotkey';
+import { Text } from '@poool/oak';
 
 import { toggleMark, withHtml } from './editor';
 import BlockButton from './BlockButton';
@@ -98,50 +99,86 @@ export default ({
           <MarkButton
             format="bold"
             icon="format_bold"
-            tooltipText="Bold"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.bold',
+                'Bold')}
+              </Text>
+            )}
           />
           <MarkButton
             format="italic"
             icon="format_italic"
-            tooltipText="Italic"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.italic',
+                'Italic')}
+              </Text>
+            )}
           />
           <MarkButton
             format="underline"
             icon="format_underlined"
-            tooltipText="Underline"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.underline',
+                'Underline')}
+              </Text>
+            )}
           />
           <ColorButton />
           <SizeButton
             icon="horizontal_rule"
             increase={false}
             currentSize={getTextSize()}
-            tooltipText="Decrease size"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.decrease',
+                'Decrease size')}
+              </Text>
+            )}
           />
           <span className="oak-text-size">{ getTextSize() }</span>
           <SizeButton
             icon="add"
             currentSize={getTextSize()}
-            tooltipText="Increase size"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.increase',
+                'Increase size')}
+              </Text>
+            )}
           />
           <BlockButton
             format="text-left"
             icon="format_align_left"
-            tooltipText="Align left"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.left',
+                'Align left')}
+              </Text>
+            )}
           />
           <BlockButton
             format="text-center"
             icon="format_align_center"
-            tooltipText="Align center"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.center',
+                'Align center')}
+              </Text>
+            )}
           />
           <BlockButton
             format="text-right"
             icon="format_align_right"
-            tooltipText="Align right"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.right',
+                'Align right')}
+              </Text>
+            )}
           />
           <BlockButton
             format="text-justify"
             icon="format_align_justify"
-            tooltipText="Align justify"
+            tooltipText={(
+              <Text>{t => t('addons.basicComponents.fields.editor.justify',
+                'Justify')}
+              </Text>
+            )}
           />
         </div>
         <Editable

--- a/packages/oak-addon-basic-components/lib/core/Editor/index.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/index.js
@@ -20,6 +20,11 @@ const HOTKEYS = {
   'mod+u': 'underline',
 };
 
+const SIZES = {
+  text: 16,
+  headings: { h1: 32, h2: 24, h3: 19, h4: 16, h5: 13, h6: 10 },
+};
+
 export default ({
   value,
   onChange,
@@ -54,28 +59,10 @@ export default ({
     });
   };
 
-  const computeSize = () => {
-    if (!element || element.type !== 'title') {
-      return 16;
-    } else {
-      switch (element.headingLevel) {
-        case 'h1':
-          return 32;
-        case 'h2':
-          return 24;
-        case 'h3':
-          return 19;
-        case 'h4':
-          return 16;
-        case 'h5':
-          return 13;
-        case 'h6':
-          return 10;
-        default:
-          return 16;
-      }
-    }
-  };
+  const getDefaultSize = () =>
+    element?.type === 'title'
+      ? SIZES.headings[element.headingLevel] || SIZES.text
+      : SIZES.text;
 
   const getTextSize = () => {
     const path = editor.selection?.anchor?.path;
@@ -85,7 +72,7 @@ export default ({
       : selectedRow?.children?.[path?.[1]];
     const selectedSize = parseInt(selectedContent?.size?.split('p')[0]);
 
-    return selectedSize || computeSize();
+    return selectedSize || getDefaultSize();
   };
 
   return (
@@ -101,7 +88,7 @@ export default ({
             icon="format_bold"
             tooltipText={(
               <Text
-                name="addons.basicComponents.fields.editor.bold_"
+                name="addons.basicComponents.fields.editor.bold"
                 default="Bold"
               />
             )}
@@ -197,7 +184,7 @@ export default ({
           spellCheck={false}
           onKeyDown={onKeyDown}
           className="oak-text-editable"
-          style={{ fontSize: computeSize() }}
+          style={{ fontSize: getDefaultSize() }}
         />
       </div>
     </Slate>

--- a/packages/oak-addon-basic-components/lib/core/Editor/index.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/index.js
@@ -101,7 +101,7 @@ export default ({
             icon="format_bold"
             tooltipText={(
               <Text
-                name="addons.basicComponents.fields.editor.bold"
+                name="addons.basicComponents.fields.editor.bold_"
                 default="Bold"
               />
             )}

--- a/packages/oak-addon-basic-components/lib/core/Editor/index.js
+++ b/packages/oak-addon-basic-components/lib/core/Editor/index.js
@@ -22,6 +22,7 @@ const HOTKEYS = {
 export default ({
   value,
   onChange,
+  element,
 }) => {
   const renderElement = useCallback(props => <Element {...props} />, []);
   const renderLeaf = useCallback(props => <Leaf {...props} />, []);
@@ -52,6 +53,29 @@ export default ({
     });
   };
 
+  const computeSize = () => {
+    if (!element || element.type !== 'title') {
+      return 16;
+    } else {
+      switch (element.headingLevel) {
+        case 'h1':
+          return 32;
+        case 'h2':
+          return 24;
+        case 'h3':
+          return 19;
+        case 'h4':
+          return 16;
+        case 'h5':
+          return 13;
+        case 'h6':
+          return 10;
+        default:
+          return 16;
+      }
+    }
+  };
+
   const getTextSize = () => {
     const path = editor.selection?.anchor?.path;
     const selectedRow = editor.children[path?.[0]];
@@ -60,7 +84,7 @@ export default ({
       : selectedRow?.children?.[path?.[1]];
     const selectedSize = parseInt(selectedContent?.size?.split('p')[0]);
 
-    return selectedSize || 16;
+    return selectedSize || computeSize();
   };
 
   return (
@@ -127,6 +151,7 @@ export default ({
           spellCheck={false}
           onKeyDown={onKeyDown}
           className="oak-text-editable"
+          style={{ fontSize: computeSize() }}
         />
       </div>
     </Slate>

--- a/packages/oak-addon-basic-components/lib/index.js
+++ b/packages/oak-addon-basic-components/lib/index.js
@@ -13,8 +13,8 @@ export default {
     type: 'richtext',
     serialize,
     deserialize,
-    render: props => (
-      <Editor { ...props } />
+    render: (baseProps, customProps) => (
+      <Editor { ...customProps } { ...baseProps } />
     ),
   }, {
     type: 'image',

--- a/packages/oak-addon-basic-components/lib/languages/fr.js
+++ b/packages/oak-addon-basic-components/lib/languages/fr.js
@@ -6,6 +6,18 @@ export default {
           add: 'Ajouter une image',
           del: 'Supprimer',
         },
+        editor: {
+          increase: 'Augmenter la taille',
+          decrease: 'Baisser la taille',
+          bold: 'Gras',
+          italic: 'Italique',
+          underline: 'Souligner',
+          color: 'Couleur',
+          left: 'Aligner à gauche',
+          center: 'Aligner au centre',
+          right: 'Aligner à droite',
+          justify: 'Justifier',
+        },
       },
       components: {
         title: {

--- a/packages/oak-addon-basic-components/lib/languages/fr.js
+++ b/packages/oak-addon-basic-components/lib/languages/fr.js
@@ -9,7 +9,7 @@ export default {
         editor: {
           increase: 'Augmenter la taille',
           decrease: 'Baisser la taille',
-          bold_: 'Gras',
+          bold: 'Gras',
           italic: 'Italique',
           underline: 'Souligner',
           color: 'Couleur',

--- a/packages/oak-addon-basic-components/lib/languages/fr.js
+++ b/packages/oak-addon-basic-components/lib/languages/fr.js
@@ -9,7 +9,7 @@ export default {
         editor: {
           increase: 'Augmenter la taille',
           decrease: 'Baisser la taille',
-          bold: 'Gras',
+          bold_: 'Gras',
           italic: 'Italique',
           underline: 'Souligner',
           color: 'Couleur',

--- a/packages/oak-addon-basic-components/package.json
+++ b/packages/oak-addon-basic-components/package.json
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.14.8",
-    "@poool/junipero": "2.0.0-rc.9",
-    "@poool/junipero-utils": "2.0.0-rc.9",
+    "@poool/junipero": "2.0.0-rc.10",
+    "@poool/junipero-utils": "2.0.0-rc.10",
     "@poool/oak": "^1.0.0-beta.11",
     "core-js": "3.15.2",
     "is-hotkey": "0.2.0",

--- a/packages/oak/package.json
+++ b/packages/oak/package.json
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.14.8",
-    "@poool/junipero": "2.0.0-rc.9",
-    "@poool/junipero-hooks": "2.0.0-rc.9",
-    "@poool/junipero-utils": "2.0.0-rc.9",
+    "@poool/junipero": "2.0.0-rc.10",
+    "@poool/junipero-hooks": "2.0.0-rc.10",
+    "@poool/junipero-utils": "2.0.0-rc.10",
     "@popperjs/core": "2.9.2",
     "core-js": "3.15.2",
     "preact": "10.5.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,6 +1289,14 @@
     core-js-pure "^3.15.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime-corejs3@7.14.9":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.9.tgz#fb21b1cf11650dcb8fcf4de2e6b3b8cf411da3f3"
+  integrity sha512-64RiH2ON4/y8qYtoa8rUiyam/tUVyGqRyNYhe+vCRGmjnV4bUlZvY+mwd0RrmLoCpJpdq3RsrNqKb7SJdw/4kw==
+  dependencies:
+    core-js-pure "^3.16.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.5.tgz#665450911c6031af38f81db530f387ec04cd9a98"
@@ -2461,6 +2469,14 @@
   dependencies:
     eslint-rule-composer "0.3.0"
 
+"@poool/junipero-hooks@2.0.0-rc.10", "@poool/junipero-hooks@^2.0.0-rc.10":
+  version "2.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@poool/junipero-hooks/-/junipero-hooks-2.0.0-rc.10.tgz#fcc2e9ac790073f05f0bfbcd1ec99da30b90c980"
+  integrity sha512-pR7DrhMTlh3W3P0MeASboQkS0yY24x0hq3hEEabY9HnYTMmEmB8TaPrxaE8SHapIdnSOd5uS49ULMQKnSVeryQ==
+  dependencies:
+    "@babel/runtime-corejs3" "7.14.9"
+    core-js "3.16.0"
+
 "@poool/junipero-hooks@2.0.0-rc.9", "@poool/junipero-hooks@^2.0.0-rc.9":
   version "2.0.0-rc.9"
   resolved "https://registry.yarnpkg.com/@poool/junipero-hooks/-/junipero-hooks-2.0.0-rc.9.tgz#7cdfe487013088b4c2d1f6ad2347af818493a014"
@@ -2469,6 +2485,14 @@
     "@babel/runtime-corejs3" "7.14.8"
     core-js "3.15.2"
 
+"@poool/junipero-utils@2.0.0-rc.10", "@poool/junipero-utils@^2.0.0-rc.10":
+  version "2.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@poool/junipero-utils/-/junipero-utils-2.0.0-rc.10.tgz#f348fec02888df4b34d7e9cfea7d7bf45a360f11"
+  integrity sha512-M3TNc2W469hlDPX1grVjt/UP4lJx9DipcG5wQUzrOALT62OhDYg/ENlizctGGAmp2QLkrbqagasCazTI7+QUcw==
+  dependencies:
+    "@babel/runtime-corejs3" "7.14.9"
+    core-js "3.16.0"
+
 "@poool/junipero-utils@2.0.0-rc.9", "@poool/junipero-utils@^2.0.0-rc.9":
   version "2.0.0-rc.9"
   resolved "https://registry.yarnpkg.com/@poool/junipero-utils/-/junipero-utils-2.0.0-rc.9.tgz#ea0880e4b563454473dba8b32f29d7df20fb3468"
@@ -2476,6 +2500,17 @@
   dependencies:
     "@babel/runtime-corejs3" "7.14.8"
     core-js "3.15.2"
+
+"@poool/junipero@2.0.0-rc.10":
+  version "2.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@poool/junipero/-/junipero-2.0.0-rc.10.tgz#70e609c32a96f6decde31ec3e1589fb4c21fdd44"
+  integrity sha512-ct07SlvRlm7kzwiL0vHoalZfhvyyoG2WUExhMviN0l+TwW+Uxk/x3QhXBaiD8sJbWQ0q599RFVbfyeTIiU0s/w==
+  dependencies:
+    "@babel/runtime-corejs3" "7.14.9"
+    "@poool/junipero-hooks" "^2.0.0-rc.10"
+    "@poool/junipero-utils" "^2.0.0-rc.10"
+    core-js "3.16.0"
+    prop-types "15.7.2"
 
 "@poool/junipero@2.0.0-rc.9":
   version "2.0.0-rc.9"
@@ -5596,6 +5631,11 @@ core-js-pure@^3.15.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.0.tgz#c19349ae0be197b8bcf304acf4d91c5e29ae2091"
   integrity sha512-RO+LFAso8DB6OeBX9BAcEGvyth36QtxYon1OyVsITNVtSKr/Hos0BXZwnsOJ7o+O6KHtK+O+cJIEj9NGg6VwFA==
 
+core-js-pure@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.16.0.tgz#218e07add3f1844e53fab195c47871fc5ba18de8"
+  integrity sha512-wzlhZNepF/QA9yvx3ePDgNGudU5KDB8lu/TRPKelYA/QtSnkS/cLl2W+TIdEX1FAFcBr0YpY7tPDlcmXJ7AyiQ==
+
 core-js-pure@^3.8.2:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.14.0.tgz#72bcfacba74a65ffce04bf94ae91d966e80ee553"
@@ -5605,6 +5645,11 @@ core-js@3.15.2:
   version "3.15.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.2.tgz#740660d2ff55ef34ce664d7e2455119c5bdd3d61"
   integrity sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
+
+core-js@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.16.0.tgz#1d46fb33720bc1fa7f90d20431f36a5540858986"
+  integrity sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g==
 
 core-js@^2.4.0:
   version "2.6.12"


### PR DESCRIPTION
This fix editor base font size to avoid text increasing in editor to result in smaller text in component. 

In addition, I also added some translations for all the content editor tooltips.

