### PR TITLE
🐛fix(options): prevent redirects on custom options

### DIFF
--- a/packages/oak/lib/core/Option/index.js
+++ b/packages/oak/lib/core/Option/index.js
@@ -14,6 +14,7 @@ export default forwardRef(({
     { ...props }
     ref={ref}
     href="#"
+    onClick={e => e.preventDefault()}
     draggable={draggable ?? false}
     className={classNames('oak-option', className)}
   >


### PR DESCRIPTION
It was missing a `preventDefault` on custom options so the clicks on those options were making a redirect.


https://user-images.githubusercontent.com/10706836/131682465-a4dbef46-9fd7-49ab-b437-59a4a9410702.mov

