### PR TITLE
🐛fix(options): remove prevent default fuckery on options, and add it on drag & drop

### DIFF
--- a/packages/oak/lib/core/Option/index.js
+++ b/packages/oak/lib/core/Option/index.js
@@ -14,7 +14,6 @@ export default forwardRef(({
     { ...props }
     ref={ref}
     href="#"
-    onClick={e => e.preventDefault()}
     draggable={draggable ?? false}
     className={classNames('oak-option', className)}
   >

--- a/packages/oak/lib/core/Row/index.options.js
+++ b/packages/oak/lib/core/Row/index.options.js
@@ -15,6 +15,7 @@ const DragOption = {
     return (
       <Draggable dragImage={dragImage} data={element}>
         <Option
+          onClick={e => e.preventDefault()}
           option={{ icon: 'drag_handle' }}
           className={classNames(className, 'oak-drag-handle')}
         />


### PR DESCRIPTION
removes preventDefault on general options button, because all the button were fucked up. Add it on drag & drop button only.