### PR TITLE
🐛fix: empty image on opening image field

### DIFF
--- a/packages/oak-addon-basic-components/lib/core/Image/index.settings.js
+++ b/packages/oak-addon-basic-components/lib/core/Image/index.settings.js
@@ -5,7 +5,7 @@ export default {
   fields: [{
     type: 'image',
     key: 'url',
-    default: [],
+    default: '',
     label: t => t(prefix + '.image.title', 'Image'),
   }, {
     type: 'select',

--- a/packages/oak/lib/core/Editable/Form.js
+++ b/packages/oak/lib/core/Editable/Form.js
@@ -85,7 +85,7 @@ export default forwardRef(({
   ), [tabs, overrides]);
 
   const getFieldKeyTypes = useCallback(() => (
-    getFields().map(f => [f.key, f.type]).filter(f => f.[0])
+    getFields().map(f => [f.key, f.type]).filter(f => f[0])
   ), [getFields]);
 
   const normalizeElement = (elmt, method) =>


### PR DESCRIPTION
Because default value was `[]` for the image field value, the 

` { state.value ? (...) : ()` was truthy on opening when no image was provided to the field. So by default the field was displaying an empty image


In addition I replaced `f.[0]` into `f[0]` in Editable/Form.js because it failed with new babel version.