### PR TITLE
✨ feat(overrides): add overrides on duplication and enable multiple overrides on a component

### DIFF
--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -5,9 +5,8 @@ import {
   useCallback,
   useImperativeHandle,
 } from 'react';
-import { mockState, cloneDeep, get } from '@poool/junipero-utils';
+import { mockState, cloneDeep, get, mergeDeep } from '@poool/junipero-utils';
 import { v4 as uuid } from 'uuid';
-import { mergeDeep } from '@poool/junipero';
 
 import { AppContext } from '../../contexts';
 import { filterOverride } from '../../utils';

--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import { mockState, cloneDeep, get } from '@poool/junipero-utils';
 import { v4 as uuid } from 'uuid';
+import { mergeDeep } from '@poool/junipero';
 
 import { AppContext } from '../../contexts';
 import { filterOverride } from '../../utils';
@@ -228,9 +229,11 @@ export default forwardRef((options, ref) => {
   const duplicateElement = (elmt, { parent = state.content } = {}) => {
     let newElmt = normalizeElement(cloneDeep(elmt), { resetIds: true });
     const component = getComponent(elmt.type);
+    const overrides = getOverrides('component', elmt.type);
+    const duplicate = overrides?.duplicate || component?.duplicate;
 
-    if (typeof component.duplicate === 'function') {
-      newElmt = component.duplicate(newElmt);
+    if (typeof duplicate === 'function') {
+      newElmt = duplicate(newElmt);
     }
 
     parent.splice(
@@ -414,15 +417,30 @@ export default forwardRef((options, ref) => {
     dispatch({ texts });
 
   const getOverrides = (type, item, opts = {}) => {
-    const overrides = state.overrides
-      ?.filter(o => o.type === type && filterOverride(type, o, item))
-      ?.pop();
+    const overrides = [];
+    state.overrides
+      .forEach(o => {
+        for (const comp of o.components) {
+          const index = overrides.findIndex(o => o.components[0] === comp);
+
+          if (index === -1) {
+            overrides.push({ ...o, components: [comp] });
+          } else {
+            overrides[index] = {
+              ...mergeDeep({ ...o }, overrides[index]),
+              components: [comp] };
+          }
+        }
+      });
+    const override = overrides?.filter(
+      o => o.type === type && filterOverride(type, o, item)
+    ).pop();
 
     switch (type) {
       case 'component':
         switch (opts.output) {
           case 'field': {
-            const field = overrides?.fields
+            const field = override?.fields
               .find(f => f.key === opts.field?.key);
 
             return Object.assign({},
@@ -430,11 +448,11 @@ export default forwardRef((options, ref) => {
               getOverrides(field?.type || opts.field?.type));
           }
           default:
-            return overrides;
+            return override;
         }
 
       case 'field':
-        return overrides;
+        return override;
     }
   };
 


### PR DESCRIPTION
This adds overrides on the duplication. 

Also it became mandatory to enable multiple overrides for a components because `button` component has 2 overrides now (richtext and duplication), the `getOverrides` method was taking only the last override found. Now we rewrite overrides array to have one component per object and all its overrides inside.

w/ @emileNetter 