### PR TITLE
✨ feat(overrides): allow overriding of construct on append

### DIFF
--- a/packages/oak/lib/core/Builder/index.js
+++ b/packages/oak/lib/core/Builder/index.js
@@ -25,14 +25,17 @@ export default () => {
   const onAppend = component => {
     const element = component.construct?.() || {};
     const overrides = getOverrides('component', element.type);
-    addElement({
+    const elementWithContent = {
       ...element,
       content: typeof element.content === 'function'
         ? element.content(getText) : element.content,
+    };
+    addElement({
+      ...elementWithContent,
       ...(
         overrides?.construct &&
         typeof overrides.construct === 'function'
-          ? overrides.construct(element)
+          ? overrides.construct(elementWithContent)
           : {}
       ),
     });

--- a/packages/oak/lib/core/Builder/index.js
+++ b/packages/oak/lib/core/Builder/index.js
@@ -18,15 +18,18 @@ export default () => {
     isUndoPossible,
     isRedoPossible,
     getText,
+    getOverrides,
   } = useBuilder();
   const { debug, historyButtonsEnabled } = useOptions();
 
   const onAppend = component => {
     const element = component.construct?.() || {};
+    const overrides = getOverrides('component', element.type);
     addElement({
       ...element,
       content: typeof element.content === 'function'
         ? element.content(getText) : element.content,
+      ...(overrides?.afterConstruct ? overrides.afterConstruct() : {}),
     });
     catalogueRef.current?.close();
   };

--- a/packages/oak/lib/core/Builder/index.js
+++ b/packages/oak/lib/core/Builder/index.js
@@ -29,7 +29,12 @@ export default () => {
       ...element,
       content: typeof element.content === 'function'
         ? element.content(getText) : element.content,
-      ...(overrides?.afterConstruct ? overrides.afterConstruct() : {}),
+      ...(
+        overrides?.afterConstruct &&
+        typeof overrides.afterConstruct === 'function'
+          ? overrides.afterConstruct()
+          : {}
+      ),
     });
     catalogueRef.current?.close();
   };

--- a/packages/oak/lib/core/Builder/index.js
+++ b/packages/oak/lib/core/Builder/index.js
@@ -30,9 +30,9 @@ export default () => {
       content: typeof element.content === 'function'
         ? element.content(getText) : element.content,
       ...(
-        overrides?.afterConstruct &&
-        typeof overrides.afterConstruct === 'function'
-          ? overrides.afterConstruct()
+        overrides?.construct &&
+        typeof overrides.construct === 'function'
+          ? overrides.construct(element)
           : {}
       ),
     });


### PR DESCRIPTION
This adds the ability to pass an `afterConstruct` method in overrides to add custom properties when appending a component.