### PR TITLE
🐛 fix(oak): prevent component being added to wrong group

### DIFF
--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -122,11 +122,14 @@ export default forwardRef((options, ref) => {
               !state.components.find(cp => cp.id === c.id)
             ) {
               state.components.push(c);
-            } else {
+            } else if (options.otherTabEnabled) {
               const group = getGroup_('other');
 
-              if (!group.components.find(cp => cp.id === c.id)) {
-                group.components.push(c);
+              if (
+                c.component &&
+                !group.components.find(cp => cp.id === c.component.id)
+              ) {
+                group.components.push(c.component);
               }
             }
           });


### PR DESCRIPTION
Issue emerged after adding `options` in dependency list causing multiple renders. A previously added group would be added a second time, leading to strange behaviors.
