### PR TITLE
🐛fix(oak): remove oak from dependencies of all packages to avoid oak version mismatches

### DIFF
--- a/packages/oak-addon-basic-components/package.json
+++ b/packages/oak-addon-basic-components/package.json
@@ -29,7 +29,6 @@
     "@babel/runtime-corejs3": "7.16.7",
     "@poool/junipero": "2.0.0-rc.15",
     "@poool/junipero-utils": "2.0.0-rc.15",
-    "@poool/oak": "^1.0.0-rc.17",
     "core-js": "3.20.2"
   },
   "scripts": {

--- a/packages/oak-addon-richtext-field-prosemirror/package.json
+++ b/packages/oak-addon-richtext-field-prosemirror/package.json
@@ -29,7 +29,6 @@
     "@babel/runtime-corejs3": "7.16.7",
     "@poool/junipero": "2.0.0-rc.15",
     "@poool/junipero-utils": "2.0.0-rc.15",
-    "@poool/oak": "^1.0.0-rc.17",
     "core-js": "3.20.2",
     "prosemirror-commands": "1.1.12",
     "prosemirror-keymap": "1.1.5",

--- a/packages/oak-addon-richtext-field/package.json
+++ b/packages/oak-addon-richtext-field/package.json
@@ -29,7 +29,6 @@
     "@babel/runtime-corejs3": "7.16.7",
     "@poool/junipero": "2.0.0-rc.15",
     "@poool/junipero-utils": "2.0.0-rc.15",
-    "@poool/oak": "^1.0.0-rc.17",
     "core-js": "3.20.2",
     "is-hotkey": "0.2.0",
     "slate": "0.72.3",


### PR DESCRIPTION
This force packages to use peer dependency for oak package and not direct dependency to avoid mismatching oak version between packages.