### PR TITLE
🐛 fix(prosemirror): change order to apply color on underline line - ACCESS-217

### DIFF
--- a/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/schema.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/schema.js
@@ -95,13 +95,6 @@ export const marks = {
       return ['span', { style: `font-size: ${node.attrs.size}` }, 0];
     },
   },
-  underline: {
-    parseDOM: [
-      { tag: 'u' },
-      { style: 'text-decoration=underline' },
-    ],
-    toDOM: () => ['span', { style: 'text-decoration: underline' }, 0],
-  },
   em: {
     parseDOM: [{ tag: 'i' }, { tag: 'em' }, { style: 'font-style=italic' }],
     toDOM: () => ['span', { style: 'font-style: italic' }, 0],
@@ -132,6 +125,13 @@ export const marks = {
     toDOM: e => {
       return ['span', { style: `color:${e?.attrs?.color}` }, 0];
     },
+  },
+  underline: {
+    parseDOM: [
+      { tag: 'u' },
+      { style: 'text-decoration=underline' },
+    ],
+    toDOM: () => ['span', { style: 'text-decoration: underline' }, 0],
   },
 };
 


### PR DESCRIPTION
Simply moved down underline component to make it applied **after** color one. Which implies color to be applied to underline line. 


Before
![Capture d’écran 2022-01-25 à 11 06 26](https://user-images.githubusercontent.com/10706836/150956690-47cf9d89-012b-4eea-896c-45f87d100b5b.png)

After
![Capture d’écran 2022-01-25 à 11 05 37](https://user-images.githubusercontent.com/10706836/150956686-183bee0a-6946-4758-8af4-2c504c6c09e2.png)
