### PR TITLE
🐛fix: disable the possibility to update content with content props after first render

### DIFF
--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -1,6 +1,5 @@
 import {
   forwardRef,
-  useEffect,
   useImperativeHandle,
   useRef,
 } from 'react';
@@ -25,10 +24,6 @@ const Builder_ = forwardRef(({
     innerRef,
     builderRef,
   }));
-
-  useEffect(() => {
-    builderRef.current?.setContent?.(value);
-  }, [value]);
 
   return (
     <div

--- a/packages/oak-react/lib/index.stories.js
+++ b/packages/oak-react/lib/index.stories.js
@@ -43,7 +43,7 @@ const BuilderWrapper = ({ onChange }) => {
   };
 
   const loadContent = () => {
-    dispatch({ value: [
+    ref.current?.builderRef.current?.setContent([
       {
         type: 'row',
         settings: {
@@ -223,7 +223,7 @@ const BuilderWrapper = ({ onChange }) => {
         ],
         id: '8bdf90df-7955-4e95-b2ce-76ac2e1a1566',
       },
-    ] });
+    ]);
   };
 
   return (

--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -38,6 +38,10 @@ export default forwardRef((options, ref) => {
     dispatch({ overrides: options.overrides || [] });
   }, [options?.overrides]);
 
+  useEffect(() => {
+    setContent(options.content);
+  }, []);
+
   useImperativeHandle(ref, () => ({
     addGroup,
     removeGroup,
@@ -135,14 +139,6 @@ export default forwardRef((options, ref) => {
           });
         }
       });
-    }
-
-    if (options.content) {
-      const content_ = cloneDeep(options.content);
-      content_.forEach(e => normalizeElement(e));
-      state.content = content_;
-      state.memory = cloneDeep([content_]);
-      state.positionInMemory = 1;
     }
 
     dispatch(state);
@@ -344,7 +340,22 @@ export default forwardRef((options, ref) => {
     }
   };
 
-  const setContent = content_ => {
+  const setContent = content => {
+
+    if (content) {
+      const content_ = cloneDeep(content);
+      content_.forEach(e => normalizeElement(e));
+      dispatch({
+        content: content_,
+        memory: cloneDeep([content_]),
+        positionInMemory: 1,
+        isUndoPossible: false,
+        isRedoPossible: false,
+      });
+    }
+  };
+
+  const setContentWithDispatch = content_ => {
     if (state.memory.length === 0 ||
       (state.memory.length === 1 && state.memory[0].length === 0)) {
       dispatch({
@@ -358,10 +369,6 @@ export default forwardRef((options, ref) => {
     dispatch({
       content: content_ || state.content,
     });
-  };
-
-  const setContentWithDispatch = content_ => {
-    setContent(content_);
     const contentCopy = cloneDeep(content_);
     contentCopy.forEach(e => serializeElement(e));
     options?.events?.onChange?.({ value: contentCopy });


### PR DESCRIPTION
The undo redo problem was due to init which was made each time `options` object changed. As this object is destructured in `oak-react` wrapper (especially with `rest` props), it was quite impossible to just memo props to avoid unecessary rerender.

I solved the problem by disabling the content replaacement when `options.content` props change after the first render. 

If the user want to force a new content to be set after the first oak render, he as to use the `setContent` method passed by the Ref (and may be by the future context wrapper). 

For me it's more logical as most of the time the new content come from oak, it hasn't to be resent to Oak after parent app as effectively changed. 