### PR TITLE
🐛fix: react rerender problems

### DIFF
--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -20,6 +20,7 @@ const Builder_ = forwardRef(({
 }, ref) => {
   const innerRef = useRef();
   const builderRef = useRef();
+
   useEffect(() => {
     const ref = render(innerRef.current, {
       ref: builderRef,

--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -1,10 +1,11 @@
 import {
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useRef,
 } from 'react';
 import { classNames } from '@poool/junipero-utils';
-import { Builder, useOptions, useBuilder, useElement } from '@poool/oak';
+import { useOptions, useBuilder, useElement, render } from '@poool/oak';
 
 export { useOptions, useBuilder, useElement };
 
@@ -19,7 +20,26 @@ const Builder_ = forwardRef(({
 }, ref) => {
   const innerRef = useRef();
   const builderRef = useRef();
+  useEffect(() => {
+    const ref = render(innerRef.current, {
+      ref: builderRef,
+      ...options,
+      ...rest,
+      content: value,
+      events: {
+        ...options.events,
+        ...rest.events,
+        onChange,
+        onImageUpload,
+      },
+    });
 
+    builderRef.current = ref;
+
+    return () => {
+      ref?.destroy();
+    };
+  }, [options]);
   useImperativeHandle(ref, () => ({
     innerRef,
     builderRef,
@@ -31,18 +51,9 @@ const Builder_ = forwardRef(({
       { ...containerProps }
       ref={innerRef}
     >
-      <Builder
-        ref={builderRef}
-        { ...options }
-        { ...rest }
-        content={value}
-        events={{
-          ...options.events,
-          ...rest.events,
-          onChange,
-          onImageUpload,
-        }}
-      />
+      {/* <Builder
+
+      /> */}
     </div>
   );
 });

--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -50,11 +50,7 @@ const Builder_ = forwardRef(({
       className={classNames('oak-react-wrapper', className)}
       { ...containerProps }
       ref={innerRef}
-    >
-      {/* <Builder
-
-      /> */}
-    </div>
+    />
   );
 });
 

--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -39,7 +39,8 @@ const Builder_ = forwardRef(({
     return () => {
       ref?.destroy();
     };
-  }, [options]);
+  }, []);
+
   useImperativeHandle(ref, () => ({
     innerRef,
     builderRef,

--- a/packages/oak/lib/index.js
+++ b/packages/oak/lib/index.js
@@ -92,7 +92,7 @@ export const render = (elmt, options = {}) => {
   return app;
 };
 
-export { Text, oak as Lib, App as Builder };
+export { Text, oak as Lib };
 
 export { useOptions, useBuilder, useElement } from './hooks';
 


### PR DESCRIPTION
Use `render` function inside a useEffect instead of App exported component `Builder` to prevent our Builder from being rerendered each times parent component is rerendered. 
