### PR TITLE
🐛 fix(lib): prevent infinite renders due to options being real props

### DIFF
--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useMemo,
   useEffect,
   useReducer,
   useCallback,
@@ -15,8 +16,9 @@ import { GROUP_CORE, GROUP_OTHER } from '../../components';
 import { BASE_FIELDTYPES } from '../../fields';
 import Builder from '../Builder';
 
-export default forwardRef((options, ref) => {
+export default forwardRef(({ options: opts, onReady }, ref) => {
   const oakRef = useRef();
+  const options = useMemo(() => opts || {}, [opts]);
   const [state, dispatch] = useReducer(mockState, {
     components: [cloneDeep(GROUP_CORE), cloneDeep(GROUP_OTHER)],
     content: [],
@@ -39,8 +41,8 @@ export default forwardRef((options, ref) => {
   }, [options?.overrides]);
 
   useEffect(() => {
-    setContent(options.content);
-    options?.onReady?.();
+    setContent(options?.content || []);
+    onReady?.();
   }, []);
 
   useImperativeHandle(ref, () => ({

--- a/packages/oak/lib/index.js
+++ b/packages/oak/lib/index.js
@@ -146,7 +146,7 @@ export const render = (elmt, options = {}) => {
 
   ReactDOM.render((
     <App
-      {...options}
+      options={options}
       onReady={app.setReady.bind(app)}
       ref={app.setRef.bind(app)}
     />


### PR DESCRIPTION
There's a world where React prevents infinite renders caused by a `useEffect` with `props` as dependencies, and there's a world where things like Preact don't.
This fixes potential infinite renders due to a bad pattern to begin with, even if React is more permissive and just ignored it all this time.