### PR TITLE
🐛fix(oak-react): add a setOptions method to update options

### DIFF
--- a/packages/oak-react/lib/index.js
+++ b/packages/oak-react/lib/index.js
@@ -43,6 +43,20 @@ const Builder_ = forwardRef(({
     };
   }, []);
 
+  useEffect(() => {
+    builderRef.current?.setOptions({
+      ...options,
+      ...rest,
+      content: value,
+      events: {
+        ...options.events,
+        ...rest.events,
+        onChange,
+        onImageUpload,
+      },
+    });
+  }, [options, onChange, onImageUpload]);
+
   useImperativeHandle(ref, () => ({
     innerRef,
     builderRef,

--- a/packages/oak-react/lib/index.stories.js
+++ b/packages/oak-react/lib/index.stories.js
@@ -10,6 +10,10 @@ export default { title: 'oak-react' };
 const BuilderWrapper = ({ onChange }) => {
   const [state, dispatch] = useReducer(mockState, {
     value: [],
+    onChange_: ({ value }) => {
+      onChange({ from: 'before handler', value });
+      dispatch({ value });
+    },
   });
   const ref = useRef();
 
@@ -21,9 +25,13 @@ const BuilderWrapper = ({ onChange }) => {
     ref.current?.builderRef.current?.redo();
   };
 
-  const onChange_ = ({ value }) => {
-    onChange({ value });
-    dispatch({ value });
+  const changeHandler = () => {
+    dispatch({
+      onChange_: ({ value }) => {
+        onChange({ from: 'after handler', value });
+        dispatch({ value });
+      },
+    });
   };
 
   // Simulate file upload
@@ -229,6 +237,7 @@ const BuilderWrapper = ({ onChange }) => {
   return (
     <>
       <div><button onClick={loadContent}>Load prebuilt appearance</button></div>
+      <button onClick={changeHandler}>Change onChange handler</button>
       <button onClick={undo}>
         Undo from parent, possible :
         {String(ref.current?.builderRef.current?.isUndoPossible())}
@@ -240,7 +249,7 @@ const BuilderWrapper = ({ onChange }) => {
       <Builder
         addons={[basicComponents]}
         value={state.value}
-        onChange={onChange_}
+        onChange={state.onChange_}
         onImageUpload={onImageUpload}
         ref={ref}
         options={{

--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -16,9 +16,8 @@ import { COMPONENT_FOLDABLE, GROUP_CORE, GROUP_OTHER } from '../../components';
 import { BASE_FIELDTYPES } from '../../fields';
 import Builder from '../Builder';
 
-export default forwardRef(({ options: opts, onReady }, ref) => {
+export default forwardRef(({ options, onReady }, ref) => {
   const oakRef = useRef();
-  const options = useMemo(() => opts || {}, [opts]);
   const [state, dispatch] = useReducer(mockState, {
     components: [
       cloneDeep(GROUP_CORE),
@@ -32,17 +31,18 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
     positionInMemory: 1,
     isUndoPossible: false,
     isRedoPossible: false,
+    options,
     texts: options?.texts || {},
     overrides: options?.overrides || [],
   });
 
   useEffect(() => {
     init();
-  }, [options]);
+  }, [state.ptions]);
 
   useEffect(() => {
-    dispatch({ overrides: options.overrides || [] });
-  }, [options?.overrides]);
+    dispatch({ overrides: state.options.overrides || [] });
+  }, [state.options?.overrides]);
 
   useEffect(() => {
     setContent(options?.content || []);
@@ -51,6 +51,7 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
 
   useImperativeHandle(ref, () => ({
     addGroup,
+    setOptions,
     removeGroup,
     addComponent,
     removeComponent,
@@ -103,8 +104,8 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
   const init = () => {
     state.fieldTypes = [...BASE_FIELDTYPES];
 
-    if (options.addons) {
-      options.addons.forEach(addon => {
+    if (state.options.addons) {
+      state.options.addons.forEach(addon => {
         if (addon.fieldTypes) {
 
           addon.fieldTypes.forEach(fieldType => {
@@ -157,7 +158,7 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
     newMemory.push(cloneDeep(content) || cloneDeep(state.content));
 
     let offset = 0;
-    const maximum = options.memoryMaximum || 100;
+    const maximum = state.options.memoryMaximum || 100;
 
     if (newMemory.length > maximum + 1) {
       offset = newMemory.length - maximum + 1;
@@ -174,7 +175,7 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
     });
     const content_ = cloneDeep(content || state.content);
     content_.forEach(e => serializeElement(e));
-    options?.events?.onChange?.({ value: content_ });
+    state.options?.events?.onChange?.({ value: content_ });
   };
 
   const getGroup_ = id => {
@@ -206,6 +207,10 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
     const group = getGroup_(groupId);
     group.components = group.components.filter(c => c.id !== id);
     dispatch({ components: state.components });
+  };
+
+  const setOptions = options => {
+    dispatch({ options });
   };
 
   const addElement = (
@@ -418,7 +423,7 @@ export default forwardRef(({ options: opts, onReady }, ref) => {
     });
     const contentCopy = cloneDeep(content_);
     contentCopy.forEach(e => serializeElement(e));
-    options?.events?.onChange?.({ value: contentCopy });
+    state.options?.events?.onChange?.({ value: contentCopy });
   };
 
   const getComponent = (type, { parent = state.components } = {}) =>

--- a/packages/oak/lib/core/App/index.js
+++ b/packages/oak/lib/core/App/index.js
@@ -38,7 +38,7 @@ export default forwardRef(({ options, onReady }, ref) => {
 
   useEffect(() => {
     init();
-  }, [state.ptions]);
+  }, [state.options]);
 
   useEffect(() => {
     dispatch({ overrides: state.options.overrides || [] });

--- a/packages/oak/lib/index.js
+++ b/packages/oak/lib/index.js
@@ -136,6 +136,14 @@ class oak {
     return this;
   }
 
+  setOptions (...args) {
+    this.#ensureMethod(() => {
+      this.#ref.current?.setOptions(...args);
+    });
+
+    return this;
+  }
+
   destroy () {
     ReactDOM.unmountComponentAtNode(this.#parent);
   }


### PR DESCRIPTION
Currently, we use `render` method (which create oak `App` component and set `options` in it) once on a useEffect with an empty dependancy array. The problem with this, is that if options change, Oak will never be aware of it, because the render is responsible of passing options from oak-react to oak.

We could choosing rerendering oak with new options each times it changes but undo/redo was affected as the memory was reset.

I so chose to add a `setOptions` method on oak, and trigger it every times options are updated on react. It allows us to keep one rendering (usefull to keep undo redo working) BUT having updated options