### PR TITLE
🐛fix(prosemirror): improve prosemirror color parsing

### DIFF
--- a/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/index.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/index.js
@@ -10,7 +10,7 @@ import { SIZES } from './utils';
 import ProseMirror from '../ProseMirror';
 import Toolbar from './Toolbar';
 
-export default ({ value, onChange, element }) => {
+export default ({ value, onChange, element, options = {} }) => {
   const viewRef = useRef();
   const [size, setSize] = useState(SIZES.text);
   const [state, setState] = useProseMirror({
@@ -99,6 +99,9 @@ export default ({ value, onChange, element }) => {
         onChange={onChange_}
         style={{ fontSize: getDefaultSize() }}
       />
+      {options.debug && (
+        <pre>{JSON.stringify(state)}</pre>
+      )}
     </div>
   );
 };

--- a/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/index.test.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/index.test.js
@@ -1,0 +1,44 @@
+import { render, waitFor } from '@testing-library/react';
+import Editor from '.';
+
+describe('<Prosemirror Editor />', () => {
+  it('should render', async () => {
+    const { container } = render(<div><Editor /></div>);
+    await waitFor(
+      () => expect(container.querySelector('.oak-prosemirror')).toBeTruthy()
+    );
+  });
+
+  it('should render with custom content', async () => {
+    const content =
+      '<span style="font-weight:bold;font-size:40px;color:#ffffff;">' +
+      'Meilleure offre' +
+      '</span>';
+    const { container } = render(
+      <div><Editor value={content} /></div>);
+    await waitFor(
+      () => expect(container.querySelector('.oak-prosemirror')).toBeDefined()
+    );
+    expect(container.querySelector('[style*="color:#ffffff"]')).toBeTruthy();
+    expect(
+      container.querySelector('[style*="font-weight: bold"]')
+    ).toBeTruthy();
+    expect(container.querySelector('[style*="font-size: 40px"]')).toBeTruthy();
+  });
+
+  it('should handle multiple paragraphs', async () => {
+    const content =
+    '<div>content</div><div></div><div>content</div>';
+    const { container } = render(
+      <div><Editor value={content} /></div>);
+    await waitFor(
+      () => expect(container.querySelector('.oak-prosemirror')).toBeDefined()
+    );
+    expect(
+      container.querySelector('.ProseMirror').querySelectorAll('div').length
+    ).toEqual(3);
+    expect(
+      container.querySelectorAll('.ProseMirror br').length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/schema.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/core/Editor/schema.js
@@ -97,7 +97,8 @@ export const marks = {
     toDOM: () => ['span', { style: 'font-style: italic' }, 0],
   },
   strong: {
-    parseDOM: [{ tag: 'strong' },
+    parseDOM: [
+      { tag: 'strong' },
       {
         tag: 'b',
         getAttrs: node => node.style.fontWeight !== 'normal' && null,
@@ -114,9 +115,9 @@ export const marks = {
       },
     },
     parseDOM: [{
-      tag: 'span',
-      getAttrs: node => {
-        return { color: node.style.color };
+      style: 'color',
+      getAttrs: color => {
+        return { color };
       },
     }],
     toDOM: e => {

--- a/packages/oak-addon-richtext-field-prosemirror/lib/hooks.test.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/hooks.test.js
@@ -1,0 +1,300 @@
+import { renderHook } from '@testing-library/react';
+import { useProseMirror } from './hooks';
+import { schema } from './core/Editor/schema';
+import { DOMParser as proseDOMParser } from 'prosemirror-model';
+
+describe('useProsemirror', () => {
+  it('should set the corect state', () => {
+    const { result } = renderHook(
+      () => useProseMirror({
+        schema,
+        doc: proseDOMParser.fromSchema(schema)
+          .parse(new DOMParser().parseFromString(
+            '<div>coucou</div>', 'text/html'
+          )),
+        docFormat: 'html' })
+    );
+    const doc = result.current[0].doc.toJSON();
+    expect(doc.type).toEqual('doc');
+    expect(doc.content.length).toEqual(1);
+
+    const paragraph = doc.content[0];
+    expect(paragraph.type).toEqual('paragraph');
+    expect(paragraph.content.length).toEqual(1);
+
+    const text = paragraph.content[0];
+    expect(text.type).toEqual('text');
+    expect(text.text).toEqual('coucou');
+  });
+  describe('with nodes', () => {
+    it('should correctly handle multiple paragraphs', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<div>hola</div><div>coucou</div>', 'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+
+      expect(doc.content.length).toEqual(2);
+      const first = doc.content[0];
+      const second = doc.content[1];
+
+      expect(first.type).toEqual('paragraph');
+      expect(first.content.length).toEqual(1);
+
+      const firstText = first.content[0];
+      expect(firstText.type).toEqual('text');
+      expect(firstText.text).toEqual('hola');
+
+      expect(second.type).toEqual('paragraph');
+      expect(second.content.length).toEqual(1);
+
+      const secondText = second.content[0];
+      expect(secondText.type).toEqual('text');
+      expect(secondText.text).toEqual('coucou');
+    });
+
+    it('should correctly parse p and div tags from content', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<p>hola</p><div>coucou</div>', 'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+      expect(doc.content.length).toEqual(2);
+      const first = doc.content[0];
+      const second = doc.content[1];
+
+      expect(first.type).toEqual('paragraph');
+      expect(first.content.length).toEqual(1);
+
+      const firstText = first.content[0];
+      expect(firstText.type).toEqual('text');
+      expect(firstText.text).toEqual('hola');
+
+      expect(second.type).toEqual('paragraph');
+      expect(second.content.length).toEqual(1);
+
+      const secondText = second.content[0];
+      expect(secondText.type).toEqual('text');
+      expect(secondText.text).toEqual('coucou');
+    });
+
+    it('should correctly parse br and empty divs from content', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<div></div><div>coucou</div><br/>', 'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+      expect(doc.content.length).toEqual(3);
+
+      const firstHardBreak = doc.content[0];
+      expect(firstHardBreak.type).toEqual('paragraph');
+      expect(firstHardBreak.content.length).toEqual(1);
+      expect(firstHardBreak.content[0]).toEqual(
+        expect.objectContaining({ type: 'hard_break' })
+      );
+
+      const middleContent = doc.content[1];
+      expect(middleContent.type).toEqual('paragraph');
+      expect(middleContent.content[0].type).toEqual('text');
+      expect(middleContent.content[0].text).toEqual('coucou');
+
+      const secondHardBreak = doc.content[2];
+      expect(secondHardBreak.type).toEqual('paragraph');
+      expect(secondHardBreak.content.length).toEqual(1);
+      expect(secondHardBreak.content[0]).toEqual(
+        expect.objectContaining({ type: 'hard_break' })
+      );
+    });
+
+    it('should handle paragraph attribute', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<div>left content</div>' +
+              '<div style="text-align:center">centered content</div>' +
+              '<div style="text-align:right">right content</div>', 'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+
+      expect(doc.content.length).toEqual(3);
+      expect(doc.content[0].attrs).toEqual(
+        expect.objectContaining({ alignment: 'left' })
+      );
+      expect(doc.content[0].content[0].text).toEqual('left content');
+
+      expect(doc.content[1].attrs).toEqual(
+        expect.objectContaining({ alignment: 'center' })
+      );
+      expect(doc.content[1].content[0].text).toEqual('centered content');
+
+      expect(doc.content[2].attrs).toEqual(
+        expect.objectContaining({ alignment: 'right' })
+      );
+      expect(doc.content[2].content[0].text).toEqual('right content');
+    });
+  });
+
+  describe('with marks', () => {
+    it('should correctly set styles', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<span style="color:#FF0000">' +
+                'red<span style="font-weight:bold">red and bold</span>' +
+              '</span>' +
+              '<span style="font-size: 2px">very small</span>',
+              'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+
+      const paragraph = doc.content[0];
+      expect(paragraph.content.length).toEqual(3);
+
+      const red = paragraph.content[0];
+      expect(red.type).toEqual('text');
+      expect(red.text).toEqual('red');
+      expect(red.marks.length).toEqual(1);
+      expect(red.marks[0]).toEqual(
+        expect.objectContaining({ type: 'color', attrs: { color: '#FF0000' } })
+      );
+
+      const redAndBold = paragraph.content[1];
+      expect(redAndBold.type).toEqual('text');
+      expect(redAndBold.text).toEqual('red and bold');
+      expect(redAndBold.marks.length).toEqual(2);
+      expect(redAndBold.marks[0]).toEqual(
+        expect.objectContaining({ type: 'strong' })
+      );
+      expect(redAndBold.marks[1]).toEqual(
+        expect.objectContaining({ type: 'color', attrs: { color: '#FF0000' } })
+      );
+
+      const small = paragraph.content[2];
+      expect(small.type).toEqual('text');
+      expect(small.text).toEqual('very small');
+      expect(small.marks.length).toEqual(1);
+
+      expect(small.marks[0]).toEqual(
+        expect.objectContaining({ type: 'size', attrs: { size: '2px' } })
+      );
+    });
+    it('should correctly handle multiple styled content', () => {
+      const marks = [
+        expect.objectContaining({
+          type: 'size',
+          attrs: {
+            size: '2px',
+          },
+        }),
+        expect.objectContaining({
+          type: 'em',
+        }),
+        expect.objectContaining({
+          type: 'strong',
+        }),
+        expect.objectContaining({
+          type: 'color',
+          attrs: {
+            color: '#FFFFFF',
+          },
+        }),
+        expect.objectContaining({
+          type: 'underline',
+        }),
+      ];
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<span ' +
+                'style="font-size: 2px; ' +
+                'color:#FFFFFF; ' +
+                'font-weight: bold; ' +
+                'text-decoration: underline; ' +
+                'font-style: italic">' +
+                  'content' +
+                '</span>',
+              'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+
+      const paragraph = doc.content[0];
+      const text = paragraph.content[0];
+
+      expect(text.marks.length).toEqual(5);
+      expect(text.marks).toEqual(expect.arrayContaining(marks));
+    });
+
+    it('should correctly handle link mark', () => {
+      const { result } = renderHook(
+        () => useProseMirror({
+          schema,
+          doc: proseDOMParser.fromSchema(schema)
+            .parse(new DOMParser().parseFromString(
+              '<a href="http://google.com">' +
+                'click <span style="color:#ffffff">me</span>' +
+              '</a>',
+              'text/html'
+            )),
+          docFormat: 'html' })
+      );
+      const doc = result.current[0].doc.toJSON();
+      const paragraph = doc.content[0];
+      expect(paragraph.content.length).toEqual(2);
+      const firstText = paragraph.content[0];
+      const secondText = paragraph.content[1];
+
+      expect(firstText.marks[0]).toEqual(
+        expect.objectContaining({
+          type: 'link',
+          attrs: {
+            href: 'http://google.com',
+            target: null,
+          },
+        })
+      );
+      expect(secondText.marks).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: 'link',
+          attrs: {
+            href: 'http://google.com',
+            target: null,
+          },
+        }),
+        expect.objectContaining({
+          type: 'color',
+          attrs: {
+            color: '#ffffff',
+          },
+        }),
+      ]));
+    });
+  });
+
+});

--- a/packages/oak-addon-richtext-field-prosemirror/lib/index.stories.js
+++ b/packages/oak-addon-richtext-field-prosemirror/lib/index.stories.js
@@ -7,7 +7,8 @@ export default { title: 'oak-addon-richtext-field-prosemirror' };
 
 export const classicEditor = () => {
   const [value, setValue] = useState(
-    'This is a <strong>fancy</strong> text<br />with a line break'
+    '<span style="text-decoration: underline; font-weight:bold;' +
+    'font-size:40px;color:#FF0000;">Meilleure offre</span>'
   );
 
   const onChange = ({ value }) => {
@@ -18,6 +19,7 @@ export const classicEditor = () => {
     <Editor
       value={value}
       onChange={onChange}
+      options={{ debug: true }}
     />
   );
 };
@@ -29,7 +31,7 @@ export const titleEditor = () => {
   const [headingLevel, setHeadingLevel] = useState('h1');
   const options = Array.from(
     { length: 6 },
-    (v, k) => ({ value: `h${k + 1}`, title: `heading ${k + 1}` })
+    (_, k) => ({ value: `h${k + 1}`, title: `heading ${k + 1}` })
   );
 
   const onChange = ({ value }) => {

--- a/packages/oak/lib/index.stories.js
+++ b/packages/oak/lib/index.stories.js
@@ -24,8 +24,10 @@ export const basicConfig = () => {
       content: [
         {
           type: 'text',
-          content: 'This is some fancy text ' +
-          '<span style="color:rgb(195, 63, 63);">content</span>',
+          content:
+          '<span style="font-weight:bold;' +
+          'font-size:40px;color:#ffffff;">Meilleure offre</span>' +
+          '</div>',
           settings: {},
           id: '81d6c270-062c-4a89-979e-a58b3c405e38',
         },


### PR DESCRIPTION
Because we used to parse color using the `span` tag type and not the color attribute inside of it, if we had many styles on a single tag, (for example `<span style="color:#ffffff: font-size: 10px">content</span>`) the color was not parsed by prosemirror and the text was considered as default (black in our case). This led us to problems when parsing complex HTML. 

In addition of this fix, I added some unit tests on our `useProsemirror` hook and on the Editor.