### PR TITLE
✨ feat(react): add builder to condition callback

### DIFF
--- a/packages/core/lib/types.d.ts
+++ b/packages/core/lib/types.d.ts
@@ -1,3 +1,5 @@
+import { Builder } from './Builder';
+
 export declare interface GetTextCallback {
   (key: string | GetTextCallback, def?: any): any;
 }
@@ -98,6 +100,7 @@ export declare interface SettingOverrideObject {
   props?: object;
   condition: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
 }
 
@@ -117,6 +120,7 @@ export declare class SettingOverride {
   props: object;
   condition: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
 }
 
@@ -135,6 +139,7 @@ export declare interface ComponentSettingsFieldObject {
   props?: object;
   condition: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
 }
 
@@ -157,6 +162,7 @@ export declare class ComponentSettingsField {
   props: object;
   condition: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
 }
 
@@ -166,6 +172,7 @@ export declare interface ComponentSettingsTabObject {
   title?: string | GetTextCallback;
   condition?: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
   fields?: Array<ComponentSettingsField | ComponentSettingsFieldObject>;
 }
@@ -180,6 +187,7 @@ export declare class ComponentSettingsTab {
   title: string | GetTextCallback;
   condition: (element: Element | ElementObject, opts?: {
     component: Component | ComponentObject;
+    builder: Builder;
   }) => boolean;
   fields: Array<ComponentSettingsField>;
 }

--- a/packages/react/lib/Editable/Field.js
+++ b/packages/react/lib/Editable/Field.js
@@ -42,7 +42,8 @@ const Field = ({
     ...overrides.field?.props,
   };
 
-  if (setting.condition && !setting.condition(element, { component })) {
+  if (setting.condition &&
+    !setting.condition(element, { component, builder })) {
     return null;
   }
 

--- a/packages/react/lib/Editable/Form.js
+++ b/packages/react/lib/Editable/Form.js
@@ -87,7 +87,8 @@ const Form = ({
           )
           .sort((a, b) => (b.priority || 0) - (a.priority || 0))
           .filter(tab => tab.type === 'tab' &&
-            (!tab.condition || tab.condition(state.element, { component })))
+            (!tab.condition ||
+              tab.condition(state.element, { component, builder })))
           .map((tab, t) => (
             <Tab key={tab.id || t} title={<Text>{ tab.title }</Text>}>
               <div className="fields oak-flex oak-flex-col oak-gap-4">
@@ -100,7 +101,8 @@ const Form = ({
                   )
                   .sort((a, b) => (b.priority || 0) - (a.priority || 0))
                   .filter(f =>
-                    !f.condition || f.condition(state.element, { component })
+                    !f.condition ||
+                    f.condition(state.element, { component, builder })
                   )
                   .map((setting, i) => (
                     <div className="field" key={i}>


### PR DESCRIPTION
This addition allows to access the builder in the `condition` callback. This offers new possibilities such as accessing the entire content and basing the condition on it.

