### PR TITLE
🐛fix: reuse getField when getting overrides

### DIFF
--- a/packages/core/lib/Overrides/index.js
+++ b/packages/core/lib/Overrides/index.js
@@ -52,8 +52,7 @@ export default class Overrides extends Emitter {
               .find(f => f.key === setting?.key);
 
             return Object.assign(
-              {},
-              this.#builder.getField(newComponentField?.type || setting?.type),
+              { type: newComponentField?.type || setting.type },
               this.#builder.getOverride('field',
                 newComponentField?.type || setting?.type),
               omit(newComponentField || {}, ['type', 'key'])

--- a/packages/core/lib/Overrides/index.js
+++ b/packages/core/lib/Overrides/index.js
@@ -53,6 +53,7 @@ export default class Overrides extends Emitter {
 
             return Object.assign(
               {},
+              this.#builder.getField(newComponentField?.type || setting?.type),
               this.#builder.getOverride('field',
                 newComponentField?.type || setting?.type),
               omit(newComponentField || {}, ['type', 'key'])

--- a/packages/react/lib/Editable/Field.js
+++ b/packages/react/lib/Editable/Field.js
@@ -11,9 +11,6 @@ const Field = ({
   editableRef,
 }) => {
   const { builder, floatingsRef } = useBuilder();
-  const field = useMemo(() => (
-    builder.getField(fieldSetting?.type)
-  ), [fieldSetting]);
 
   const overrides = useMemo(() => ({
     field: builder.getOverride('component', element.type, {
@@ -21,7 +18,11 @@ const Field = ({
     }),
     settings: builder
       .getOverride('setting', element.type, { setting: fieldSetting }),
-  }), [element, field]);
+  }), [element, fieldSetting]);
+
+  const field = useMemo(() => (
+    builder.getField(overrides?.field?.type || fieldSetting?.type)
+  ), [overrides, fieldSetting]);
 
   const setting = useMemo(() => ({
     ...fieldSetting,


### PR DESCRIPTION
Don't really understand why this has been deleted on the #1147 ?

Reusing this field overrides make ckeditor working again, and seems to be useful as the builder stores fields overrides in the fields 

https://github.com/p3ol/oak/blob/0947dcbc8522311f7893c437418f71ea55296244/packages/core/lib/Builder/index.js#L71-L74

What do you think guys ? @antoinechassagne @dackmin 
