### PR TITLE
🐛 fix: correctly handle settings overrides

### DIFF
--- a/packages/core/lib/classes.ts
+++ b/packages/core/lib/classes.ts
@@ -149,7 +149,7 @@ export class Field {
   static FIND_PREDICATE = (type: string) => (f: Field) => f.type === type;
 
   type: string;
-  render: (props: any) => any;
+  render: FieldObject['render'];
   props: object;
 
   constructor (props: FieldObject) {
@@ -179,15 +179,13 @@ export class ComponentOverride extends Override {
   id: string;
   targets: string[];
   fields: ComponentSettingsFieldObject[];
-  render: Function;
+  render: ComponentOverrideObject['render'];
   construct: (
     opts: { builder: Builder, baseElement?: ElementObject }
   ) => ElementObject;
-  sanitize: (
-    element: ElementObject, { builder }: { builder: Builder}
-  ) => ElementObject;
-  duplicate: Function; //TODO fix it
-  deserialize: Function; //TODO fix it
+  sanitize: ComponentOverrideObject['sanitize'];
+  duplicate: ComponentOverrideObject['duplicate'];
+  deserialize: ComponentOverrideObject['deserialize'];
   priority: number;
   serialize: Function; //TODO fix it
   getContainers: (element: ElementObject) => ElementObject[][];
@@ -208,16 +206,32 @@ export class ComponentOverride extends Override {
     this.priority = props.priority || 0;
     this.editable = props.editable;
   }
+
+  toObject (): ComponentOverrideObject {
+    return {
+      type: 'component',
+      id: this.id,
+      targets: this.targets,
+      fields: this.fields,
+      render: this.render,
+      sanitize: this.sanitize,
+      construct: this.construct,
+      duplicate: this.duplicate,
+      deserialize: this.deserialize,
+      priority: this.priority,
+      editable: this.editable,
+    };
+  }
 }
 
 export class FieldOverride extends Override {
   id: string;
   targets: Array<any>;
-  render: Function;
+  render: FieldOverrideObject['render'];
   props: object;
   construct: Function;
   priority: number;
-  onChange: Function;
+  onChange: FieldOverrideObject['onChange'];
 
   constructor (props: FieldOverrideObject) {
     super();
@@ -230,6 +244,19 @@ export class FieldOverride extends Override {
     this.props = props.props || {};
     this.construct = props.construct;
     this.onChange = props.onChange;
+  }
+
+  toObject (): FieldOverrideObject {
+    return {
+      type: 'field',
+      id: this.id,
+      targets: this.targets,
+      render: this.render,
+      priority: this.priority,
+      props: this.props,
+      construct: this.construct,
+      onChange: this.onChange,
+    };
   }
 }
 
@@ -244,10 +271,11 @@ export class SettingOverride extends Override {
   description: string | GetTextCallback;
   displayable: boolean;
   valueType: string;
-  condition: Function;
+  condition: SettingOverrideObject['condition'];
   priority: number;
-  fields: ComponentSettingsFieldObject[];
+  fields: ComponentSettingsField[];
   props: object;
+  info: string | GetTextCallback;
 
   constructor (props: SettingOverrideObject) {
     super();
@@ -265,10 +293,32 @@ export class SettingOverride extends Override {
     this.valueType = props.valueType;
     this.condition = props.condition;
     this.priority = props.priority || 0;
+    this.info = props.info;
     this.fields = (props.fields || []).map((
       f: ComponentSettingsFieldObject
     ) => new ComponentSettingsField(f));
     this.props = props.props;
+  }
+
+  toObject (): SettingOverrideObject {
+    return {
+      type: 'setting',
+      key: this.key,
+      targets: this.targets,
+      id: this.id,
+      placeholder: this.placeholder,
+      default: this.default,
+      options: this.options,
+      label: this.label,
+      description: this.description,
+      displayable: this.displayable,
+      valueType: this.valueType,
+      condition: this.condition,
+      priority: this.priority,
+      info: this.info,
+      fields: this.fields.map(f => f.toObject()),
+      props: this.props,
+    };
   }
 }
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -30,9 +30,7 @@ export declare interface ComponentSettingsFieldKeyTuple {
 export declare interface FieldObject {
   type: string;
   props?: object;
-  render?(props: any, opts?: {
-    setting: ComponentSettingsFieldObject;
-  }): any;
+  render?(props: any, opts?: any): any; // TODO fix this
   deserialize?(val: string): any;
   onChange?<T = any>(
     field: FieldContent<T>,
@@ -47,8 +45,10 @@ export declare interface ComponentOverrideObject {
   fields?: ComponentSettingsFieldObject[];
   construct?(opts?: { builder?: Builder }): ElementObject;
   deserialize?(opts?: { builder?: Builder }): ElementObject;
-  render?(props?: any): any;
-  sanitize?(elmt?: ElementObject): any;
+  render?(props?: any, opts?: any): any; // TODO fix this
+  sanitize?(elmt?: ElementObject, opts?: {
+    builder: Builder;
+  }): ElementObject;
   duplicate?(elmt?: ElementObject): ElementObject;
   priority?: number;
   editable?: boolean;

--- a/packages/react/lib/DisplayableSettings/Property.tsx
+++ b/packages/react/lib/DisplayableSettings/Property.tsx
@@ -30,14 +30,12 @@ const Property = ({
 
   const value = useMemo(() => (
     get(element, field.key as string, field.default)
-  ), [element, field]);
+  ), [element, Object.values(element), field]);
 
   const option = useMemo(() => (
-    field.options
-      ? field.options.find(
-        (o: { value: ComponentSettingsFieldOptionObject[]}) =>
-          o.value === value || o === value)
-      : null
+    field.options?.find((o: ComponentSettingsFieldOptionObject) => (
+      o.value === value || o === value
+    ))
   ), [field, value]);
 
   return (

--- a/packages/react/lib/Editable/Field.tsx
+++ b/packages/react/lib/Editable/Field.tsx
@@ -1,7 +1,3 @@
-import {
-  type MutableRefObject,
-  useMemo,
-} from 'react';
 import type {
   ComponentObject,
   ComponentSettingsFieldObject,
@@ -12,9 +8,14 @@ import type {
 import type {
   SpecialComponentPropsWithoutRef,
 } from '@junipero/react';
+import {
+  type MutableRefObject,
+  useMemo,
+} from 'react';
 
+import type { EditableRef } from './index';
 import { useBuilder } from '../hooks';
-import { EditableRef } from '.';
+import { assignDefined } from '../utils';
 
 export interface FieldProps extends SpecialComponentPropsWithoutRef {
   setting: ComponentSettingsFieldObject;
@@ -47,11 +48,12 @@ const Field = ({
     builder.getField(overrides?.field?.type || fieldSetting?.type)
   ), [overrides, fieldSetting, addons]);
 
-  const setting = useMemo(() => ({
-    ...fieldSetting,
-    ...overrides.settings,
-    ...overrides.field,
-  }), [fieldSetting, overrides, addons]);
+  const setting = useMemo(() => assignDefined<typeof fieldSetting>(
+    { type: fieldSetting.type },
+    fieldSetting,
+    overrides.settings?.toObject?.() || overrides.settings || {},
+    overrides.field?.toObject?.() || overrides.field || {},
+  ), [fieldSetting, overrides, addons]);
 
   const fieldProps = {
     id: setting.id,

--- a/packages/react/lib/Editable/Setting.tsx
+++ b/packages/react/lib/Editable/Setting.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useMemo, type MutableRefObject } from 'react';
+import {
+  SettingOverride,
+  type ComponentObject,
+  type ComponentSettingsFieldObject,
+  type ElementObject,
+  type FieldObject,
+  type FieldOverride,
+  type FieldOverrideObject,
+} from '@oakjs/core';
+import {
+  type FieldContent,
+  Abstract,
+  FieldControl,
+  Label,
+  Tooltip,
+  classNames,
+} from '@junipero/react';
+
+import type { EditableRef } from './index';
+import Text from '../Text';
+import Icon from '../Icon';
+import Field from './Field';
+import { useBuilder } from '../hooks';
+
+export interface SettingProps {
+  setting: ComponentSettingsFieldObject;
+  component: ComponentObject;
+  element: ElementObject;
+  editableRef?: MutableRefObject<EditableRef>;
+  onSettingChange?(name: string, field: FieldContent): void;
+  onSettingCustomChange?(
+    name: string,
+    renderer: FieldOverride | FieldObject | FieldOverrideObject,
+    field: FieldContent
+  ): void;
+}
+
+const Setting = ({
+  setting,
+  component,
+  element,
+  editableRef,
+  onSettingChange,
+  onSettingCustomChange,
+}: SettingProps) => {
+  const { builder } = useBuilder();
+
+  const override = useMemo(() => (
+    builder.getOverride('setting', element.type, { setting }) as SettingOverride
+  ), [element, setting]);
+
+  const hasSubfields = useMemo(() => (
+    Array.isArray(override?.fields || setting.fields) &&
+    (override?.fields || setting.fields).length > 0
+  ), [setting, override]);
+
+  return (
+    <div className="field">
+      <FieldControl>
+        { (override?.label || setting.label) && (
+          <Label
+            className="oak-flex oak-items-center oak-gap-2"
+          >
+            <Text>{ (override?.label || setting.label) as string }</Text>
+            { (override?.info || setting.info) && (
+              <Tooltip
+                text={
+                  <Text>{ (override?.info || setting.info) as string }</Text>
+                }
+              >
+                <Icon className="!oak-text-[18px]">
+                  info_circle
+                </Icon>
+              </Tooltip>
+            ) }
+          </Label>
+        ) }
+        { hasSubfields ? (
+          <div
+            className={classNames(
+              'sub-fields oak-flex oak-gap-2',
+            )}
+          >
+            { (override?.fields || setting.fields).map((f, n) => (
+              <div className="field" key={n}>
+                <FieldControl>
+                  { f.label && (
+                    <Label
+                      className={classNames(
+                        'field-label oak-flex oak-items-center',
+                        'oak-gap-1'
+                      )}
+                    >
+                      <Text>{ f.label as string }</Text>
+                      { f.info && (
+                        <Tooltip
+                          text={
+                            <Text>{ f.info as string }</Text>
+                          }
+                        >
+                          <Icon className="!oak-text-[14px]">
+                            info_circle
+                          </Icon>
+                        </Tooltip>
+                      ) }
+                    </Label>
+                  ) }
+                  <Field
+                    setting={f}
+                    editableRef={editableRef}
+                    element={element}
+                    component={component}
+                    onChange={onSettingChange}
+                    onCustomChange={onSettingCustomChange}
+                  />
+                </FieldControl>
+              </div>
+            )) }
+          </div>
+        ) : (
+          <Field
+            setting={setting}
+            editableRef={editableRef}
+            element={element}
+            component={component}
+            onChange={onSettingChange}
+            onCustomChange={onSettingCustomChange}
+          />
+        ) }
+        { (override?.description || setting.description) && (
+          <Abstract className="secondary">
+            <Text>{ override?.description || setting.description }</Text>
+          </Abstract>
+        ) }
+      </FieldControl>
+    </div>
+  );
+};
+
+Setting.displayName = 'Setting';
+
+export default Setting;

--- a/packages/react/lib/Editable/Setting.tsx
+++ b/packages/react/lib/Editable/Setting.tsx
@@ -1,13 +1,13 @@
-import { useCallback, useMemo, type MutableRefObject } from 'react';
-import {
+import type {
   SettingOverride,
-  type ComponentObject,
-  type ComponentSettingsFieldObject,
-  type ElementObject,
-  type FieldObject,
-  type FieldOverride,
-  type FieldOverrideObject,
+  ComponentObject,
+  ComponentSettingsFieldObject,
+  ElementObject,
+  FieldObject,
+  FieldOverride,
+  FieldOverrideObject,
 } from '@oakjs/core';
+import { type MutableRefObject, useMemo } from 'react';
 import {
   type FieldContent,
   Abstract,
@@ -18,10 +18,10 @@ import {
 } from '@junipero/react';
 
 import type { EditableRef } from './index';
+import { useBuilder } from '../hooks';
 import Text from '../Text';
 import Icon from '../Icon';
 import Field from './Field';
-import { useBuilder } from '../hooks';
 
 export interface SettingProps {
   setting: ComponentSettingsFieldObject;

--- a/packages/react/lib/Editable/Tab.tsx
+++ b/packages/react/lib/Editable/Tab.tsx
@@ -1,0 +1,98 @@
+import type { Key, MutableRefObject } from 'react';
+import type {
+  ComponentObject,
+  ComponentSettingsTabObject,
+  ComponentSettingsFieldObject,
+  ElementObject,
+  ComponentOverride,
+  SettingOverride,
+  FieldOverride,
+  FieldObject,
+  FieldOverrideObject,
+} from '@oakjs/core';
+import { type FieldContent, cloneDeep } from '@junipero/react';
+
+import type { EditableRef } from './index';
+import { useBuilder } from '../hooks';
+import Setting from './Setting';
+
+export interface TabProps {
+  tab: ComponentSettingsTabObject;
+  component: ComponentObject;
+  element: ElementObject;
+  overrides?: ComponentOverride | SettingOverride | FieldOverride;
+  editableRef?: MutableRefObject<EditableRef>;
+  onSettingChange?(name: string, field: FieldContent): void;
+  onSettingCustomChange?(
+    name: string,
+    renderer: FieldOverride | FieldObject | FieldOverrideObject,
+    field: FieldContent
+  ): void;
+  onUpdate?(elmt: ElementObject): void;
+}
+
+const Tab = ({
+  tab,
+  component,
+  element,
+  overrides,
+  editableRef,
+  onUpdate,
+  onSettingChange,
+  onSettingCustomChange,
+}: TabProps) => {
+  const { builder } = useBuilder();
+
+  const getFieldPriority = (field: ComponentSettingsFieldObject) => {
+    const fieldOverride = {
+      ...builder.getOverride('setting', element.type, { setting: field }),
+      ...builder.getOverride('component', element.type, {
+        output: 'field', setting: field,
+      }),
+    };
+
+    return Number.isSafeInteger(fieldOverride?.priority)
+      ? fieldOverride.priority
+      : field.priority || 0;
+  };
+
+  return (
+    <div className="fields oak-flex oak-flex-col oak-gap-4">
+      { (component.settings?.fields || [])
+        .filter((field: ComponentSettingsFieldObject) =>
+          (tab.id === 'general' && !field.tab) ||
+          field.tab === tab.id
+        )
+        .concat(tab.fields)
+        .sort((
+          a: ComponentSettingsFieldObject,
+          b: ComponentSettingsFieldObject
+        ) => getFieldPriority(b) - getFieldPriority(a))
+        .filter((f: ComponentSettingsFieldObject) =>
+          !f.condition ||
+          f.condition(element, { component, builder })
+        )
+        .map((setting: ComponentSettingsFieldObject, i: Key) => (
+          <Setting
+            key={i}
+            setting={setting}
+            component={component}
+            element={element}
+            editableRef={editableRef}
+            onSettingChange={onSettingChange}
+            onSettingCustomChange={onSettingCustomChange}
+          />
+        )) }
+      { tab?.renderForm?.({
+        element: cloneDeep(element),
+        component,
+        overrides,
+        update: onUpdate,
+      }) }
+    </div>
+  );
+};
+
+Tab.displayName = 'Tab';
+
+export default Tab;

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -303,3 +303,19 @@ export const withNonEditableComponents = () => (
     onChange={action('change')}
   />
 );
+
+export const withSettingOverrides = () => (
+  <Builder
+    addons={[baseAddon(), {
+      overrides: [{
+        type: 'setting',
+        targets: ['*'],
+        key: 'responsive.xl',
+        info: 'Test',
+      }],
+    }]}
+    value={baseContent}
+    options={{ debug: true }}
+    onChange={action('change')}
+  />
+);

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -24,3 +24,23 @@ export const sanitizeHTML = (content: string) => {
     return '';
   }
 };
+
+export function assignDefined<T extends any> (
+  target: T,
+  ...sources: Array<any>
+): T {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key in source) {
+      if (typeof source[key] !== 'undefined') {
+        // @ts-ignore it's obviously any
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+}


### PR DESCRIPTION
This PR:
- Fixes settings overrides -> no more disappearing properties
- Fixes displayable properties not being re-rendered when an editable updates an element content
- Introduces some types `TODO`s because I'm tired and want to play elden ring