### PR TITLE
✨ feat(react): add background preview to col component

### DIFF
--- a/packages/react/lib/components/Col/index.tsx
+++ b/packages/react/lib/components/Col/index.tsx
@@ -18,6 +18,7 @@ import Text from '../../Text';
 
 export interface ColProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
+  parent: ElementObject[];
   depth?: number;
   onPrepend?: () => void;
   onAppend?: () => void;
@@ -27,6 +28,7 @@ export interface ColProps extends ComponentPropsWithoutRef<'div'> {
 const Col = ({
   element,
   className,
+  parent = [],
   depth = 0,
   onPrepend,
   onAppend,
@@ -258,6 +260,24 @@ const Col = ({
 
       { component && (
         <div className="options oak-flex oak-items-center oak-gap-0.5">
+          { (
+            element.styles?.backgroundColor ||
+            element.styles?.backgroundImage
+          ) && parent.length <= 6 && (
+            <div
+              className={classNames(
+                'oak-mr-2 oak-rounded-full oak-w-[15px]',
+                'oak-h-[15px] oak-bg-no-repeat oak-bg-center oak-bg-cover',
+              )}
+              style={{
+                backgroundColor: element.styles?.backgroundColor,
+                ...element.styles?.backgroundImage && {
+                  backgroundImage:
+                    `url(${element.styles?.backgroundImage.url})`,
+                },
+              }}
+            />
+          )}
           { (
             (override as ComponentOverrideObject)?.editable ??
             component.editable

--- a/packages/react/lib/components/Row/index.tsx
+++ b/packages/react/lib/components/Row/index.tsx
@@ -103,6 +103,7 @@ const Row = ({
             key={i}
             depth={depth}
             element={col}
+            parent={element.cols}
             onPrepend={onDivide.bind(null, i, true)}
             onAppend={onDivide.bind(null, i, false)}
             onRemove={onRemoveCol.bind(null, i)}


### PR DESCRIPTION
<img width="2247" alt="Capture d’écran 2024-06-28 à 10 41 10" src="https://github.com/p3ol/oak/assets/1873323/c462157b-02e2-49c3-8750-2d6e5cac1f1b">

Background preview already exists on row, but is a nice to have on col too.
It will disappear when the parent row has more than 6 cols to avoid cluttering the col options.