### PR TITLE
🐛 fix: correctly handle custom fields from component overrides

### DIFF
--- a/packages/core/lib/addons.ts
+++ b/packages/core/lib/addons.ts
@@ -584,6 +584,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
       label: (
         t: GetTextCallback
       ) => t('core.components.button.settings.content.title', 'Content'),
+      priority: 50,
     }, {
       type: 'select',
       key: 'action',
@@ -605,6 +606,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
         ),
         value: 'event',
       }],
+      priority: 40,
     }, {
       type: 'text',
       key: 'url',
@@ -615,6 +617,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
         t: GetTextCallback
       ) => t('core.components.button.settings.url.title', 'Link URL'),
       condition: (element: ElementObject) => element.action === 'link',
+      priority: 30,
     }, {
       type: 'select',
       key: 'target',
@@ -639,6 +642,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
         ),
         value: '_blank',
       }],
+      priority: 20,
     }, {
       type: 'text',
       key: 'event',
@@ -649,6 +653,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
         'Javascript event name'
       ),
       condition: (element: ElementObject) => element.action === 'event',
+      priority: 10,
     }, {
       type: 'select',
       key: 'settings.buttonType',
@@ -668,6 +673,7 @@ export const buttonComponent = (props?: ComponentObject): ComponentObject => ({
         ) => t('core.components.button.settings.type.links', '<a>'),
         value: 'link',
       }],
+      priority: 1,
     }],
   },
   editable: true,

--- a/packages/react/lib/DisplayableSettings/index.tsx
+++ b/packages/react/lib/DisplayableSettings/index.tsx
@@ -43,15 +43,29 @@ const DisplayableSettings = ({
       : setting.priority || 0;
   };
 
-  const displayableSettings = useMemo(() => (
-    builder
-      .getComponentDisplayableSettings(element, { component })
+  const displayableSettings = useMemo(() => {
+    const settings = builder
+      .getComponentDisplayableSettings(element, { component });
+
+    return settings
+      // Append fields that are only defined inside the component override
+      .concat(override?.fields?.filter(f => (
+        !settings.find(s =>
+          s.type !== 'tab' &&
+          (s as ComponentSettingsFieldObject).key === f.key)
+      )) || [])
       .filter(s => !s.condition || s.condition(element))
       .sort((a, b) =>
         getSettingPriority(b as SettingOverrideObject) -
         getSettingPriority(a as SettingOverrideObject)
-      )
-  ), [element, component]);
+      );
+  }, [
+    element,
+    // Only checking on element prevents from updating the render when a sub
+    // property of the element changes
+    Object.values(element),
+    component,
+  ]);
 
   if (displayableSettings.length <= 0) {
     return null;

--- a/packages/react/lib/Editable/Tab.tsx
+++ b/packages/react/lib/Editable/Tab.tsx
@@ -1,5 +1,5 @@
-import type { Key, MutableRefObject } from 'react';
-import type {
+import { type Key, type MutableRefObject, useMemo } from 'react';
+import {
   ComponentObject,
   ComponentSettingsTabObject,
   ComponentSettingsFieldObject,
@@ -42,6 +42,9 @@ const Tab = ({
   onSettingCustomChange,
 }: TabProps) => {
   const { builder } = useBuilder();
+  const componentOverride = useMemo(() => (
+    builder.getOverride('component', element.type) as ComponentOverride
+  ), [element.type]);
 
   const getFieldPriority = (field: ComponentSettingsFieldObject) => {
     const fieldOverride = {
@@ -59,6 +62,13 @@ const Tab = ({
   return (
     <div className="fields oak-flex oak-flex-col oak-gap-4">
       { (component.settings?.fields || [])
+        // Append fields that are only defined inside the component override
+        .concat(componentOverride?.fields?.filter(f =>
+          !component.settings?.fields?.find(s =>
+            s.type !== 'tab' &&
+            (s as ComponentSettingsFieldObject).key === f.key
+          )
+        ) || [])
         .filter((field: ComponentSettingsFieldObject) =>
           (tab.id === 'general' && !field.tab) ||
           field.tab === tab.id

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -237,6 +237,37 @@ export const withMultipleCustomSettingsAndFields = () => (
   />
 );
 
+export const withComponentOverride = () => (
+  <Builder
+    addons={[baseAddon(), {
+      overrides: [{
+        id: 'buttonOverride',
+        type: 'component',
+        targets: ['button'],
+        fields: [{
+          key: 'action',
+          type: 'select',
+          options: [
+            { value: 'link', title: 'Open a link' },
+            { value: 'third-party', title: 'Open a third-party service' },
+          ],
+        }, {
+          key: 'thirdPartyService',
+          type: 'text',
+          label: 'Third party service ID',
+          priority: 2,
+          displayable: true,
+          condition: (element: ElementObject) =>
+            element.action === 'third-party',
+        }],
+      }],
+    } as AddonObject]}
+    value={baseContent}
+    options={{ debug: true }}
+    onChange={action('change')}
+  />
+);
+
 export const disallowSomeChildren = () => (
   <div>
     <div>You should not be able to add a text inside a col</div>


### PR DESCRIPTION
Fields only declared inside a component override are currently ignored and not rendered.

As settings fields declared inside a component override are already considered in typings as `ComponentSettingsFieldObject`s, it seemed natural to handle them accordingly and append these fields inside the editable form.