### PR TITLE
🐛 fix: prevent incorrect displayable settings

### DIFF
--- a/packages/core/lib/Builder/index.ts
+++ b/packages/core/lib/Builder/index.ts
@@ -164,14 +164,18 @@ export default class Builder extends Emitter {
 
   getComponentDisplayableSettings (
     element: ElementObject,
-    { component }: { component: ComponentObject}
+    { component, override }: {
+      component: ComponentObject;
+      override?: ComponentOverrideObject | ComponentOverride;
+    },
   ): Array<ComponentSettingsTabObject | ComponentSettingsFieldObject> {
     const component_ = new Component(component);
+    const override_ = new ComponentOverride(override ?? {});
 
     return [
       ...this.#components
         .getDisplayableSettings?.(
-          element, { component: component_ }
+          element, { component: component_, override: override_ }
         ) || [],
       ...this.#settings.getDisplayable?.(element) || [],
     ];

--- a/packages/core/lib/Components/index.ts
+++ b/packages/core/lib/Components/index.ts
@@ -1,11 +1,13 @@
 import type {
   ComponentObject,
+  ComponentSettingsFieldObject,
   ComponentsGroupObject,
   ElementObject,
   GetTextCallback,
 } from '../types';
 import {
   Component,
+  ComponentOverride,
   ComponentSettingsField,
   ComponentSettingsTab,
   ComponentsGroup,
@@ -206,9 +208,10 @@ export default class Components extends Emitter implements IComponents {
 
   getDisplayableSettings (
     element: ElementObject,
-    { fields, component }: {
+    { fields, component, override }: {
       fields?: Array<ComponentSettingsField | ComponentSettingsTab>;
       component?: Component;
+      override?: ComponentOverride;
     } = {}
   ) {
     const displayable: Array<ComponentSettingsField> = [];
@@ -222,6 +225,14 @@ export default class Components extends Emitter implements IComponents {
 
       fields = component?.settings.fields;
     }
+
+    // Append fields that are only defined inside the component override
+    fields = fields.concat(override?.fields?.filter(f => (
+      !component?.settings?.fields.find(s =>
+        s.type !== 'tab' &&
+        (s as ComponentSettingsField).key === f.key
+      )
+    )) || []);
 
     for (const setting of fields) {
       if (Array.isArray(setting.fields)) {

--- a/packages/core/lib/classes.ts
+++ b/packages/core/lib/classes.ts
@@ -52,8 +52,8 @@ export class Component {
   usable: boolean;
   editable: boolean;
   disallow: any;
-  options: any;
-  settings: any;
+  options?: ComponentOption[];
+  settings?: ComponentSettingsForm;
   deserialize: (opts: { builder: Builder }) => ElementObject;
   serialize: Function; //TODO
 
@@ -100,7 +100,7 @@ export class Component {
       droppable: this.droppable,
       usable: this.usable,
       editable: this.editable,
-      options: this.options,
+      options: this.options?.map(o => o.toObject?.() ?? o),
       disallow: this.disallow,
       render: this.render,
       sanitize: this.sanitize,
@@ -178,7 +178,7 @@ export class Override {
 export class ComponentOverride extends Override {
   id: string;
   targets: string[];
-  fields: ComponentSettingsFieldObject[];
+  fields: ComponentSettingsField[];
   render: ComponentOverrideObject['render'];
   construct: (
     opts: { builder: Builder, baseElement?: ElementObject }
@@ -192,13 +192,13 @@ export class ComponentOverride extends Override {
   editable: boolean;
   disallow: string[];
 
-  constructor (props: ComponentOverrideObject) {
+  constructor (props: ComponentOverrideObject | ComponentOverride) {
     super();
 
     this.type = 'component';
     this.id = props.id;
     this.targets = props.targets || [];
-    this.fields = props.fields || [];
+    this.fields = (props.fields || []).map(f => new ComponentSettingsField(f));
     this.render = props.render;
     this.sanitize = props.sanitize;
     this.construct = props.construct;
@@ -214,7 +214,7 @@ export class ComponentOverride extends Override {
       type: 'component',
       id: this.id,
       targets: this.targets,
-      fields: this.fields,
+      fields: this.fields?.map(f => f.toObject?.() ?? f),
       render: this.render,
       sanitize: this.sanitize,
       construct: this.construct,
@@ -330,11 +330,18 @@ export class SettingOverride extends Override {
 
 export class ComponentOption {
   icon: any;
-  render: Function;
+  render: any;
 
   constructor (props: ComponentOptionObject) {
     this.icon = props.icon;
     this.render = props.render;
+  }
+
+  toObject (): ComponentOptionObject {
+    return {
+      icon: this.icon,
+      render: this.render,
+    };
   }
 }
 

--- a/packages/react/lib/DisplayableSettings/index.tsx
+++ b/packages/react/lib/DisplayableSettings/index.tsx
@@ -45,15 +45,9 @@ const DisplayableSettings = ({
 
   const displayableSettings = useMemo(() => {
     const settings = builder
-      .getComponentDisplayableSettings(element, { component });
+      .getComponentDisplayableSettings(element, { component, override });
 
     return settings
-      // Append fields that are only defined inside the component override
-      .concat(override?.fields?.filter(f => (
-        !settings.find(s =>
-          s.type !== 'tab' &&
-          (s as ComponentSettingsFieldObject).key === f.key)
-      )) || [])
       .filter(s => !s.condition || s.condition(element))
       .sort((a, b) =>
         getSettingPriority(b as SettingOverrideObject) -


### PR DESCRIPTION
#1480 introduced a slight bug where settings overrides would incorrectly become displayable. This PR fixes this.

