### PR TITLE
✨feat(react): add a collapse option for inner content blocks on builder

### DIFF
--- a/packages/react/lib/Builder/index.test.tsx.snap
+++ b/packages/react/lib/Builder/index.test.tsx.snap
@@ -516,11 +516,13 @@ exports[`<Builder /> should allow to add content from catalogue: Content with te
           <div
             class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
           >
-            <h6
-              class="junipero oak-m-0"
-            >
-              Text
-            </h6>
+            <div>
+              <h6
+                class="junipero oak-inline oak-m-0"
+              >
+                Text
+              </h6>
+            </div>
             <div
               class="element-content oak-flex-auto"
             >
@@ -643,11 +645,13 @@ exports[`<Builder /> should allow to add content from catalogue: Content with te
                       <div
                         class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
                       >
-                        <h6
-                          class="junipero oak-m-0"
-                        >
-                          Title
-                        </h6>
+                        <div>
+                          <h6
+                            class="junipero oak-inline oak-m-0"
+                          >
+                            Title
+                          </h6>
+                        </div>
                         <div
                           class="element-content oak-flex-auto"
                         >
@@ -1068,11 +1072,13 @@ exports[`<Builder /> should allow to add content from catalogue: Row with title 
                 <div
                   class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
                 >
-                  <h6
-                    class="junipero oak-m-0"
-                  >
-                    Title
-                  </h6>
+                  <div>
+                    <h6
+                      class="junipero oak-inline oak-m-0"
+                    >
+                      Title
+                    </h6>
+                  </div>
                   <div
                     class="element-content oak-flex-auto"
                   >
@@ -1367,11 +1373,13 @@ exports[`<Builder /> should allow to add content programmatically: Content with 
             <div
               class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
             >
-              <h6
-                class="junipero oak-m-0"
-              >
-                Title
-              </h6>
+              <div>
+                <h6
+                  class="junipero oak-inline oak-m-0"
+                >
+                  Title
+                </h6>
+              </div>
               <div
                 class="element-content oak-flex-auto"
               >
@@ -1839,11 +1847,13 @@ exports[`<Builder /> should allow to render editable inside a modal: Title edita
           <div
             class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
           >
-            <h6
-              class="junipero oak-m-0"
-            >
-              Title
-            </h6>
+            <div>
+              <h6
+                class="junipero oak-inline oak-m-0"
+              >
+                Title
+              </h6>
+            </div>
             <div
               class="element-content oak-flex-auto"
             >
@@ -2189,11 +2199,13 @@ exports[`<Builder /> should render: Base content 1`] = `
           <div
             class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
           >
-            <h6
-              class="junipero oak-m-0"
-            >
-              Title
-            </h6>
+            <div>
+              <h6
+                class="junipero oak-inline oak-m-0"
+              >
+                Title
+              </h6>
+            </div>
             <div
               class="element-content oak-flex-auto"
             >
@@ -2288,11 +2300,13 @@ exports[`<Builder /> should render: Base content 1`] = `
           <div
             class="element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2 oak-justify-between"
           >
-            <h6
-              class="junipero oak-m-0"
-            >
-              Text
-            </h6>
+            <div>
+              <h6
+                class="junipero oak-inline oak-m-0"
+              >
+                Text
+              </h6>
+            </div>
             <div
               class="element-content oak-flex-auto"
             >

--- a/packages/react/lib/Builder/index.test.tsx.snap
+++ b/packages/react/lib/Builder/index.test.tsx.snap
@@ -375,6 +375,17 @@ exports[`<Builder /> should allow to add content from catalogue: Content with ro
             </i>
           </a>
           <a
+            class="option oak-flex oak-items-center oak-justify-center option"
+            draggable="false"
+            href="#"
+          >
+            <i
+              class="icon junipero-icons !oak-text-lg"
+            >
+              expand_less
+            </i>
+          </a>
+          <a
             class="option oak-flex oak-items-center oak-justify-center edit"
             draggable="false"
             href="#"
@@ -834,6 +845,17 @@ exports[`<Builder /> should allow to add content from catalogue: Content with te
             </i>
           </a>
           <a
+            class="option oak-flex oak-items-center oak-justify-center option"
+            draggable="false"
+            href="#"
+          >
+            <i
+              class="icon junipero-icons !oak-text-lg"
+            >
+              expand_less
+            </i>
+          </a>
+          <a
             class="option oak-flex oak-items-center oak-justify-center edit"
             draggable="false"
             href="#"
@@ -1245,6 +1267,17 @@ exports[`<Builder /> should allow to add content from catalogue: Row with title 
         class="icon junipero-icons !oak-text-lg"
       >
         pause
+      </i>
+    </a>
+    <a
+      class="option oak-flex oak-items-center oak-justify-center option"
+      draggable="false"
+      href="#"
+    >
+      <i
+        class="icon junipero-icons !oak-text-lg"
+      >
+        expand_less
       </i>
     </a>
     <a

--- a/packages/react/lib/DynamicComponent/index.tsx
+++ b/packages/react/lib/DynamicComponent/index.tsx
@@ -1,0 +1,14 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+export declare interface DynamicComponentProps
+  extends ComponentPropsWithoutRef<any> {
+    render: React.FC<any>;
+}
+
+const DynamicComponent = (
+  { render: Renderer, ...props }: DynamicComponentProps
+) => (
+  <Renderer {...props} />
+);
+
+export default DynamicComponent;

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -111,7 +111,10 @@ const Element = forwardRef<ElementRef, ElementProps>(({
 
   const unfoldBlock = (e: MouseEvent<HTMLElement>) => {
     e?.preventDefault();
-    builder.setElement(element.id, { collapsed: false });
+
+    if (element.collapsed) {
+      builder.setElement(element.id, { collapsed: false });
+    }
   };
 
   const rendered = (
@@ -150,7 +153,9 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                 className={classNames(
                   'inner oak-flex oak-gap-2 oak-p-4 oak-items-stretch',
                   depth % 2 === 0 ? 'even' : 'odd',
+                  { 'oak-cursor-pointer': element.collapsed },
                 )}
+                onClick={unfoldBlock}
               >
                 <Icon
                   children={typeof component?.icon === 'function'
@@ -173,7 +178,6 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                           'junipero extra',
                           '!oak-text-alternate-text-color oak-ml-1'
                         )}
-                        onClick={unfoldBlock}
                       >
                         <Text name="core.components.collapsed">
                           (expand to see inner content)

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -139,58 +139,59 @@ const Element = forwardRef<ElementRef, ElementProps>(({
             className
           )}
         >
-          { component?.hasCustomInnerContent ? rendered : component ? (
-            <div
-              className={classNames(
-                'inner oak-flex oak-gap-2 oak-p-4 oak-items-stretch',
-                depth % 2 === 0 ? 'even' : 'odd',
-              )}
-            >
-              <Icon
-                children={typeof component?.icon === 'function'
-                  ? component.icon.bind(null, component)
-                  : component?.icon}
-              />
+          { component?.hasCustomInnerContent && !element.collapsed
+            ? rendered : component ? (
               <div
                 className={classNames(
-                  'element-info oak-flex-auto oak-flex oak-flex-col oak-gap-2',
-                  'oak-justify-between'
+                  'inner oak-flex oak-gap-2 oak-p-4 oak-items-stretch',
+                  depth % 2 === 0 ? 'even' : 'odd',
                 )}
               >
-                <h6 className="junipero oak-m-0">
-                  <Text>{ component?.name as string }</Text>
-                </h6>
-                { rendered && (
-                  <div className="element-content oak-flex-auto">
-                    { rendered }
-                  </div>
-                ) }
-
-                <DisplayableSettings
-                  element={element}
-                  component={component}
-                  override={override as ComponentOverrideObject}
+                <Icon
+                  children={typeof component?.icon === 'function'
+                    ? component.icon.bind(null, component)
+                    : component?.icon}
                 />
-              </div>
-            </div>
-          ) : (
-            <div
-              className={classNames(
-                'inner oak-flex oak-gap-2 oak-p-4',
-                depth % 2 === 0 ? 'even' : 'odd'
-              )}
-            >
-              <Icon>help_circle</Icon>
-              <div className="element-info">
-                <h6 className="junipero oak-m-0 oak-mb-2">
-                  <Text name="core.components.unknown">Unknown</Text>
-                </h6>
-                <div className="element-content">
-                  { JSON.stringify(element) }
+                <div
+                  className={classNames(
+                    'element-info oak-flex-auto oak-flex oak-flex-col',
+                    'oak-gap-2 oak-justify-between'
+                  )}
+                >
+                  <h6 className="junipero oak-m-0">
+                    <Text>{ component?.name as string }</Text>
+                  </h6>
+                  { rendered && (
+                    <div className="element-content oak-flex-auto">
+                      { rendered }
+                    </div>
+                  ) }
+
+                  <DisplayableSettings
+                    element={element}
+                    component={component}
+                    override={override as ComponentOverrideObject}
+                  />
                 </div>
               </div>
-            </div>
-          ) }
+            ) : (
+              <div
+                className={classNames(
+                  'inner oak-flex oak-gap-2 oak-p-4',
+                  depth % 2 === 0 ? 'even' : 'odd'
+                )}
+              >
+                <Icon>help_circle</Icon>
+                <div className="element-info">
+                  <h6 className="junipero oak-m-0 oak-mb-2">
+                    <Text name="core.components.unknown">Unknown</Text>
+                  </h6>
+                  <div className="element-content">
+                    { JSON.stringify(element) }
+                  </div>
+                </div>
+              </div>
+            ) }
 
           <div
             className={classNames(

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -109,6 +109,11 @@ const Element = forwardRef<ElementRef, ElementProps>(({
     copyToClipboard(JSON.stringify(element));
   };
 
+  const unfoldBlock = (e: MouseEvent<HTMLElement>) => {
+    e?.preventDefault();
+    builder.setElement(element.id, { collapsed: false });
+  };
+
   const rendered = (
     (override as ComponentOverrideObject)?.render ||
     component?.render
@@ -168,6 +173,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                           'junipero extra',
                           '!oak-text-alternate-text-color oak-ml-1'
                         )}
+                        onClick={unfoldBlock}
                       >
                         <Text name="core.components.collapsed">
                           (expand to see inner content)

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -158,10 +158,24 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                     'oak-gap-2 oak-justify-between'
                   )}
                 >
-                  <h6 className="junipero oak-m-0">
-                    <Text>{ component?.name as string }</Text>
-                  </h6>
-                  { rendered && (
+                  <div>
+                    <h6 className="junipero oak-inline oak-m-0">
+                      <Text>{ component?.name as string }</Text>
+                    </h6>
+                    { element.collapsed && (
+                      <span
+                        className={classNames(
+                          'junipero extra',
+                          '!oak-text-alternate-text-color oak-ml-1'
+                        )}
+                      >
+                        <Text name="core.components.collapsed">
+                          (expand to see inner content)
+                        </Text>
+                      </span>
+                    )}
+                  </div>
+                  { !element.collapsed && rendered && (
                     <div className="element-content oak-flex-auto">
                       { rendered }
                     </div>

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -3,13 +3,11 @@ import type {
   ComponentOverride,
   ComponentOverrideObject,
   ElementObject,
-  FieldOverrideObject,
 } from '@oakjs/core';
 import {
   type ComponentPropsWithoutRef,
   type MouseEvent,
   type MutableRefObject,
-  Fragment,
   forwardRef,
   useMemo,
   useRef,
@@ -28,6 +26,7 @@ import {
 
 import type { EditableRef } from '../Editable';
 import type { OakRef, ReactComponentObject } from '../types';
+import { type ElementContextValue, ElementContext } from '../contexts';
 import { copyToClipboard } from '../utils';
 import { useBuilder } from '../hooks';
 import DisplayableSettings from '../DisplayableSettings';
@@ -35,6 +34,7 @@ import Icon from '../Icon';
 import Option from '../Option';
 import Text from '../Text';
 import Editable from '../Editable';
+import DynamicComponent from '../DynamicComponent';
 
 export interface ElementProps extends ComponentPropsWithoutRef<any> {
   element?: ElementObject;
@@ -59,6 +59,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
   const editableRef = useRef<EditableRef>();
   const modalRef = useRef<ModalRef>();
   const [editableOpened, setEditableOpened] = useState(false);
+  const [elementCollapsed, setElementCollapsed] = useState(false);
   const { builder, addons } = useBuilder();
 
   useImperativeHandle(ref, () => ({
@@ -75,6 +76,14 @@ const Element = forwardRef<ElementRef, ElementProps>(({
   const parentOverride = useMemo(() => (
     builder.getOverride('component', parentComponent?.id) as ComponentOverride
   ), [parentComponent, builder, addons]);
+
+  const getElementContext = useCallback((): ElementContextValue => {
+    return {
+      element,
+      collapsed: elementCollapsed,
+      toggleCollapse: () => setElementCollapsed(v => !v),
+    };
+  }, [element, elementCollapsed, setElementCollapsed]);
 
   const onDelete_ = (e: MouseEvent<HTMLAnchorElement>) => {
     e?.preventDefault();
@@ -109,13 +118,13 @@ const Element = forwardRef<ElementRef, ElementProps>(({
     copyToClipboard(JSON.stringify(element));
   };
 
-  const unfoldBlock = (e: MouseEvent<HTMLElement>) => {
+  const unfoldBlock = useCallback((e: MouseEvent<HTMLElement>) => {
     e?.preventDefault();
 
-    if (element.collapsed) {
-      builder.setElement(element.id, { collapsed: false });
+    if (elementCollapsed) {
+      setElementCollapsed(false);
     }
-  };
+  }, [elementCollapsed, setElementCollapsed]);
 
   const rendered = (
     (override as ComponentOverrideObject)?.render ||
@@ -131,172 +140,176 @@ const Element = forwardRef<ElementRef, ElementProps>(({
   }) || null;
 
   return (
-    <Droppable
-      ref={innerRef}
-      disabled={component?.droppable === false}
-      onDrop={onDrop_}
-    >
-      <Draggable
-        data={element}
-        disabled={component?.draggable === false || editableOpened}
+    <ElementContext.Provider value={getElementContext()}>
+      <Droppable
+        ref={innerRef}
+        disabled={component?.droppable === false}
+        onDrop={onDrop_}
       >
-        <div
-          className={classNames(
-            'oak element oak-flex-none',
-            'type-' + (component?.id || 'unknown'),
-            className
-          )}
+        <Draggable
+          data={element}
+          disabled={component?.draggable === false || editableOpened}
         >
-          { component?.hasCustomInnerContent && !element.collapsed
-            ? rendered : component ? (
-              <div
-                className={classNames(
-                  'inner oak-flex oak-gap-2 oak-p-4 oak-items-stretch',
-                  depth % 2 === 0 ? 'even' : 'odd',
-                  { 'oak-cursor-pointer': element.collapsed },
-                )}
-                onClick={unfoldBlock}
-              >
-                <Icon
-                  children={typeof component?.icon === 'function'
-                    ? component.icon.bind(null, component)
-                    : component?.icon}
-                />
-                <div
-                  className={classNames(
-                    'element-info oak-flex-auto oak-flex oak-flex-col',
-                    'oak-gap-2 oak-justify-between'
-                  )}
-                >
-                  <div>
-                    <h6 className="junipero oak-inline oak-m-0">
-                      <Text>{ component?.name as string }</Text>
-                    </h6>
-                    { element.collapsed && (
-                      <span
-                        className={classNames(
-                          'junipero extra',
-                          '!oak-text-alternate-text-color oak-ml-1'
-                        )}
-                      >
-                        <Text name="core.components.collapsed">
-                          (expand to see inner content)
-                        </Text>
-                      </span>
-                    )}
-                  </div>
-                  { !element.collapsed && rendered && (
-                    <div className="element-content oak-flex-auto">
-                      { rendered }
-                    </div>
-                  ) }
-
-                  <DisplayableSettings
-                    element={element}
-                    component={component}
-                    override={override as ComponentOverrideObject}
-                  />
-                </div>
-              </div>
-            ) : (
-              <div
-                className={classNames(
-                  'inner oak-flex oak-gap-2 oak-p-4',
-                  depth % 2 === 0 ? 'even' : 'odd'
-                )}
-              >
-                <Icon>help_circle</Icon>
-                <div className="element-info">
-                  <h6 className="junipero oak-m-0 oak-mb-2">
-                    <Text name="core.components.unknown">Unknown</Text>
-                  </h6>
-                  <div className="element-content">
-                    { JSON.stringify(element) }
-                  </div>
-                </div>
-              </div>
-            ) }
-
           <div
             className={classNames(
-              'options oak-flex oak-items-center',
-              { 'oak-has-inner-content': component?.hasCustomInnerContent },
-              { opened: editableOpened }
+              'oak element oak-flex-none',
+              'type-' + (component?.id || 'unknown'),
+              className
             )}
           >
-            <Option
-              option={{ icon: 'close' }}
-              className="remove"
-              onClick={onDelete_}
-              name={<Text name="core.tooltips.remove">Remove</Text> }
-            />
-            <Option
-              option={{ icon: 'copy' }}
-              className="duplicate"
-              onClick={onDuplicate_}
-              name={(
-                <Text name="core.tooltips.duplicate">Duplicate</Text>
+            { component?.hasCustomInnerContent && !elementCollapsed
+              ? rendered : component ? (
+                <div
+                  className={classNames(
+                    'inner oak-flex oak-gap-2 oak-p-4 oak-items-stretch',
+                    depth % 2 === 0 ? 'even' : 'odd',
+                    { 'oak-cursor-pointer': elementCollapsed },
+                  )}
+                  onClick={unfoldBlock}
+                >
+                  <Icon
+                    children={typeof component?.icon === 'function'
+                      ? component.icon.bind(null, component)
+                      : component?.icon}
+                  />
+                  <div
+                    className={classNames(
+                      'element-info oak-flex-auto oak-flex oak-flex-col',
+                      'oak-gap-2 oak-justify-between'
+                    )}
+                  >
+                    <div>
+                      <h6 className="junipero oak-inline oak-m-0">
+                        <Text>{ component?.name as string }</Text>
+                      </h6>
+                      { elementCollapsed && (
+                        <span
+                          className={classNames(
+                            'junipero extra',
+                            '!oak-text-alternate-text-color oak-ml-1'
+                          )}
+                        >
+                          <Text name="core.components.collapsed">
+                            (expand to see inner content)
+                          </Text>
+                        </span>
+                      )}
+                    </div>
+                    { !elementCollapsed && rendered && (
+                      <div className="element-content oak-flex-auto">
+                        { rendered }
+                      </div>
+                    ) }
+
+                    <DisplayableSettings
+                      element={element}
+                      component={component}
+                      override={override as ComponentOverrideObject}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div
+                  className={classNames(
+                    'inner oak-flex oak-gap-2 oak-p-4',
+                    depth % 2 === 0 ? 'even' : 'odd'
+                  )}
+                >
+                  <Icon>help_circle</Icon>
+                  <div className="element-info">
+                    <h6 className="junipero oak-m-0 oak-mb-2">
+                      <Text name="core.components.unknown">Unknown</Text>
+                    </h6>
+                    <div className="element-content">
+                      { JSON.stringify(element) }
+                    </div>
+                  </div>
+                </div>
+              ) }
+
+            <div
+              className={classNames(
+                'options oak-flex oak-items-center',
+                { 'oak-has-inner-content': component?.hasCustomInnerContent },
+                { opened: editableOpened }
               )}
-            />
-            <Option
-              option={{ icon: 'copy_file' }}
-              className="copy"
-              onClick={onCopy_}
-              name={<Text name="core.tooltips.copy">Copy</Text>}
-            />
-            { (component?.options || []).map((o, i) => (
-              <Fragment key={i}>
-                { o?.render?.({
-                  option: o,
-                  className: 'option',
-                  element,
-                  elementInnerRef: innerRef,
-                  editableRef,
-                  parent,
-                  component,
-                  builder,
-                  index: i,
-                }) }
-              </Fragment>
-            )) }
-            { (
-              (override as ComponentOverrideObject)?.editable ??
-              component?.editable
-            ) && (
-              <Editable
-                element={element}
-                component={component}
-                ref={editableRef}
-                modalRef={modalRef}
-                setOpened={setEditableOpened}
-                opened={editableOpened}
-              >
-                <Option
-                  option={{ icon: 'pen' }}
-                  className="edit"
-                  name={<Text name="core.tooltips.edit">Edit</Text>}
+            >
+              <Option
+                option={{ icon: 'close' }}
+                className="remove"
+                onClick={onDelete_}
+                name={<Text name="core.tooltips.remove">Remove</Text> }
+              />
+              <Option
+                option={{ icon: 'copy' }}
+                className="duplicate"
+                onClick={onDuplicate_}
+                name={(
+                  <Text name="core.tooltips.duplicate">Duplicate</Text>
+                )}
+              />
+              <Option
+                option={{ icon: 'copy_file' }}
+                className="copy"
+                onClick={onCopy_}
+                name={<Text name="core.tooltips.copy">Copy</Text>}
+              />
+              { (component?.options || []).map((o, i) => (
+                <DynamicComponent
+                  render={o.render}
+                  key={i}
+                  option={o}
+                  className="option"
+                  element={element}
+                  elementInnerRef={innerRef}
+                  editableRef={editableRef}
+                  parent={parent}
+                  component={component}
+                  builder={builder}
+                  index={i}
                 />
-              </Editable>
+              ))}
+              { ((override as ComponentOverrideObject)?.editable ??
+                component?.editable
+              ) && (
+                <Editable
+                  element={element}
+                  component={component}
+                  ref={editableRef}
+                  modalRef={modalRef}
+                  setOpened={setEditableOpened}
+                  opened={editableOpened}
+                >
+                  <Option
+                    option={{ icon: 'pen' }}
+                    className="edit"
+                    name={<Text name="core.tooltips.edit">Edit</Text>}
+                  />
+                </Editable>
+              ) }
+            </div>
+            { builder.options.debug && (
+              <Tooltip
+                className="extra"
+                text="Print debug in console"
+                placement="left"
+              >
+                <span
+                  className="debug oak-cursor-pointer"
+                  onClick={onPrintDebug}
+                >
+                  <Icon
+                    className="!oak-text-sm !oak-text-alternate-text-color"
+                  >
+                    settings
+                  </Icon>
+                </span>
+              </Tooltip>
             ) }
           </div>
-          { builder.options.debug && (
-            <Tooltip
-              className="extra"
-              text="Print debug in console"
-              placement="left"
-            >
-              <span className="debug oak-cursor-pointer" onClick={onPrintDebug}>
-                <Icon
-                  className="!oak-text-sm !oak-text-alternate-text-color"
-                >
-                  settings
-                </Icon>
-              </span>
-            </Tooltip>
-          ) }
-        </div>
-      </Draggable>
-    </Droppable>
+        </Draggable>
+      </Droppable>
+    </ElementContext.Provider>
   );
 });
 

--- a/packages/react/lib/addons.tsx
+++ b/packages/react/lib/addons.tsx
@@ -16,7 +16,7 @@ import { slideInDownMenu } from '@junipero/transitions';
 import * as coreAddons from '@oakjs/core/addons';
 
 import type { ReactComponentObject, ReactFieldObject } from './types';
-import { dragOption, backgroundColorOption } from './options';
+import { dragOption, backgroundColorOption, collapseOption } from './options';
 import { type ImageFieldProps, ImageField } from './fields';
 import {
   Button,
@@ -155,7 +155,7 @@ export const rowComponent = (
 ): ReactComponentObject => ({
   ...coreAddons.rowComponent(),
   render: Row,
-  options: [dragOption(), backgroundColorOption()],
+  options: [dragOption(), collapseOption(), backgroundColorOption()],
   ...props,
 });
 
@@ -211,7 +211,7 @@ export const foldableComponent = (
   props?: ReactComponentObject
 ): ReactComponentObject => ({
   ...coreAddons.foldableComponent(),
-  options: [dragOption()],
+  options: [dragOption(), collapseOption()],
   render: Foldable,
   ...props,
 });
@@ -221,7 +221,7 @@ export const clickableComponent = (
 ): ReactComponentObject => ({
   ...coreAddons.clickableComponent(),
   render: Clickable,
-  options: [dragOption(), backgroundColorOption()],
+  options: [dragOption(), collapseOption(), backgroundColorOption()],
   ...props,
 });
 

--- a/packages/react/lib/components/Clickable/index.tsx
+++ b/packages/react/lib/components/Clickable/index.tsx
@@ -53,39 +53,61 @@ const Clickable = ({
   ]);
 
   return (
-    <div
-      { ...omit(rest, ['builder']) }
-      className={classNames(
-        'wrapper',
-        depth % 2 === 0 ? 'even' : 'odd',
-        className,
-      )}
-      data-depth={depth}
-    >
-      <Droppable onDrop={onDropElement.bind(null, 'before')}>
-        <div className="drop-zone before" />
-      </Droppable>
-      <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
-        <div className="section">
+    <>
+      { element.collapsed
+        ? (
           <div
-            className="title junipero secondary !oak-text-alternate-text-color"
+            { ...omit(rest, ['builder', 'component']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
           >
-            <Text name="core.components.clickable.sectionsTitle.content">
-              Clickable content
+            <Text name="core.components.clickable.collapsed">
+              Collapsed clickable (expand to see inner content)
             </Text>
           </div>
-          <Container
-            depth={depth + 1}
-            element={element}
-            content={element.content as ElementObject[]}
-            component={component}
-          />
-        </div>
-      </div>
-      <Droppable onDrop={onDropElement.bind(null, 'after')}>
-        <div className="drop-zone after" />
-      </Droppable>
-    </div>
+        ) : (
+          <div
+            { ...omit(rest, ['builder']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
+            data-depth={depth}
+          >
+            <Droppable onDrop={onDropElement.bind(null, 'before')}>
+              <div className="drop-zone before" />
+            </Droppable>
+            <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
+              <div className="section">
+                <div
+                  className={classNames(
+                    'title junipero secondary',
+                    '!oak-text-alternate-text-color'
+                  )}
+                >
+                  <Text name="core.components.clickable.sectionsTitle.content">
+                    Clickable content
+                  </Text>
+                </div>
+                <Container
+                  depth={depth + 1}
+                  element={element}
+                  content={element.content as ElementObject[]}
+                  component={component}
+                />
+              </div>
+            </div>
+            <Droppable onDrop={onDropElement.bind(null, 'after')}>
+              <div className="drop-zone after" />
+            </Droppable>
+          </div>
+        )
+      }
+    </>
   );
 };
 

--- a/packages/react/lib/components/Clickable/index.tsx
+++ b/packages/react/lib/components/Clickable/index.tsx
@@ -76,7 +76,7 @@ const Clickable = ({
                 )}
               >
                 <Text name="core.components.clickable.sectionsTitle.content">
-                    Clickable content
+                  Clickable content
                 </Text>
               </div>
               <Container

--- a/packages/react/lib/components/Clickable/index.tsx
+++ b/packages/react/lib/components/Clickable/index.tsx
@@ -54,59 +54,44 @@ const Clickable = ({
 
   return (
     <>
-      { element.collapsed
-        ? (
-          <div
-            { ...omit(rest, ['builder', 'component']) }
-            className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-          >
-            <Text name="core.components.clickable.collapsed">
-              Collapsed clickable (expand to see inner content)
-            </Text>
-          </div>
-        ) : (
-          <div
-            { ...omit(rest, ['builder']) }
-            className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-            data-depth={depth}
-          >
-            <Droppable onDrop={onDropElement.bind(null, 'before')}>
-              <div className="drop-zone before" />
-            </Droppable>
-            <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
-              <div className="section">
-                <div
-                  className={classNames(
-                    'title junipero secondary',
-                    '!oak-text-alternate-text-color'
-                  )}
-                >
-                  <Text name="core.components.clickable.sectionsTitle.content">
+      { !element.collapsed && (
+        <div
+          { ...omit(rest, ['builder']) }
+          className={classNames(
+            'wrapper',
+            depth % 2 === 0 ? 'even' : 'odd',
+            className,
+          )}
+          data-depth={depth}
+        >
+          <Droppable onDrop={onDropElement.bind(null, 'before')}>
+            <div className="drop-zone before" />
+          </Droppable>
+          <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
+            <div className="section">
+              <div
+                className={classNames(
+                  'title junipero secondary',
+                  '!oak-text-alternate-text-color'
+                )}
+              >
+                <Text name="core.components.clickable.sectionsTitle.content">
                     Clickable content
-                  </Text>
-                </div>
-                <Container
-                  depth={depth + 1}
-                  element={element}
-                  content={element.content as ElementObject[]}
-                  component={component}
-                />
+                </Text>
               </div>
+              <Container
+                depth={depth + 1}
+                element={element}
+                content={element.content as ElementObject[]}
+                component={component}
+              />
             </div>
-            <Droppable onDrop={onDropElement.bind(null, 'after')}>
-              <div className="drop-zone after" />
-            </Droppable>
           </div>
-        )
-      }
+          <Droppable onDrop={onDropElement.bind(null, 'after')}>
+            <div className="drop-zone after" />
+          </Droppable>
+        </div>
+      )}
     </>
   );
 };

--- a/packages/react/lib/components/Foldable/index.tsx
+++ b/packages/react/lib/components/Foldable/index.tsx
@@ -53,69 +53,98 @@ const Foldable = ({
   ]);
 
   return (
-    <div
-      { ...omit(rest, ['builder']) }
-      className={classNames(
-        'wrapper',
-        depth % 2 === 0 ? 'even' : 'odd',
-        className,
-      )}
-      data-depth={depth}
-    >
-      <Droppable onDrop={onDropElement.bind(null, 'before')}>
-        <div className="drop-zone before" />
-      </Droppable>
-      <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
-        <div className="section">
+    <>
+      { element.collapsed
+        ? (
           <div
-            className="title junipero secondary !oak-text-alternate-text-color"
+            { ...omit(rest, ['builder', 'component']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
           >
-            <Text name="core.components.foldable.sectionsTitle.seeMore">
-              Label when collapsed
+            <Text name="core.components.foldable.collapsed">
+              Collapsed foldable (expand to see inner content)
             </Text>
           </div>
-          <Container
-            depth={depth + 1}
-            element={element}
-            content={element.seeMore}
-            component={component}
-          />
-        </div>
-        <div className="section">
+        )
+        : (
           <div
-            className="title junipero secondary !oak-text-alternate-text-color"
+            { ...omit(rest, ['builder']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
+            data-depth={depth}
           >
-            <Text name="core.components.foldable.sectionsTitle.seeLess">
-              Label when expanded
-            </Text>
+            <Droppable onDrop={onDropElement.bind(null, 'before')}>
+              <div className="drop-zone before" />
+            </Droppable>
+            <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
+              <div className="section">
+                <div
+                  className={classNames(
+                    'title junipero secondary',
+                    '!oak-text-alternate-text-color'
+                  )}
+                >
+                  <Text name="core.components.foldable.sectionsTitle.seeMore">
+                    Label when collapsed
+                  </Text>
+                </div>
+                <Container
+                  depth={depth + 1}
+                  element={element}
+                  content={element.seeMore}
+                  component={component}
+                />
+              </div>
+              <div className="section">
+                <div
+                  className={classNames(
+                    'title junipero secondary',
+                    '!oak-text-alternate-text-color'
+                  )}
+                >
+                  <Text name="core.components.foldable.sectionsTitle.seeLess">
+                    Label when expanded
+                  </Text>
+                </div>
+                <Container
+                  depth={depth + 1}
+                  element={element}
+                  content={element.seeLess}
+                  component={component}
+                />
+              </div>
+              <div className="section">
+                <div
+                  className={classNames(
+                    'title junipero secondary',
+                    '!oak-text-alternate-text-color'
+                  )}
+                >
+                  <Text name="core.components.foldable.sectionsTitle.content">
+                    Content
+                  </Text>
+                </div>
+                <Container
+                  depth={depth + 1}
+                  element={element}
+                  content={element.content as ElementObject[]}
+                  component={component}
+                />
+              </div>
+            </div>
+            <Droppable onDrop={onDropElement.bind(null, 'after')}>
+              <div className="drop-zone after" />
+            </Droppable>
           </div>
-          <Container
-            depth={depth + 1}
-            element={element}
-            content={element.seeLess}
-            component={component}
-          />
-        </div>
-        <div className="section">
-          <div
-            className="title junipero secondary !oak-text-alternate-text-color"
-          >
-            <Text name="core.components.foldable.sectionsTitle.content">
-              Content
-            </Text>
-          </div>
-          <Container
-            depth={depth + 1}
-            element={element}
-            content={element.content as ElementObject[]}
-            component={component}
-          />
-        </div>
-      </div>
-      <Droppable onDrop={onDropElement.bind(null, 'after')}>
-        <div className="drop-zone after" />
-      </Droppable>
-    </div>
+        )
+      }
+    </>
   );
 };
 

--- a/packages/react/lib/components/Foldable/index.tsx
+++ b/packages/react/lib/components/Foldable/index.tsx
@@ -54,96 +54,80 @@ const Foldable = ({
 
   return (
     <>
-      { element.collapsed
-        ? (
-          <div
-            { ...omit(rest, ['builder', 'component']) }
-            className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-          >
-            <Text name="core.components.foldable.collapsed">
-              Collapsed foldable (expand to see inner content)
-            </Text>
-          </div>
-        )
-        : (
-          <div
-            { ...omit(rest, ['builder']) }
-            className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-            data-depth={depth}
-          >
-            <Droppable onDrop={onDropElement.bind(null, 'before')}>
-              <div className="drop-zone before" />
-            </Droppable>
-            <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
-              <div className="section">
-                <div
-                  className={classNames(
-                    'title junipero secondary',
-                    '!oak-text-alternate-text-color'
-                  )}
-                >
-                  <Text name="core.components.foldable.sectionsTitle.seeMore">
+      { !element.collapsed && (
+        <div
+          { ...omit(rest, ['builder']) }
+          className={classNames(
+            'wrapper',
+            depth % 2 === 0 ? 'even' : 'odd',
+            className,
+          )}
+          data-depth={depth}
+        >
+          <Droppable onDrop={onDropElement.bind(null, 'before')}>
+            <div className="drop-zone before" />
+          </Droppable>
+          <div className="sections oak-flex oak-flex-col oak-gap-4 oak-p-4">
+            <div className="section">
+              <div
+                className={classNames(
+                  'title junipero secondary',
+                  '!oak-text-alternate-text-color'
+                )}
+              >
+                <Text name="core.components.foldable.sectionsTitle.seeMore">
                     Label when collapsed
-                  </Text>
-                </div>
-                <Container
-                  depth={depth + 1}
-                  element={element}
-                  content={element.seeMore}
-                  component={component}
-                />
+                </Text>
               </div>
-              <div className="section">
-                <div
-                  className={classNames(
-                    'title junipero secondary',
-                    '!oak-text-alternate-text-color'
-                  )}
-                >
-                  <Text name="core.components.foldable.sectionsTitle.seeLess">
-                    Label when expanded
-                  </Text>
-                </div>
-                <Container
-                  depth={depth + 1}
-                  element={element}
-                  content={element.seeLess}
-                  component={component}
-                />
-              </div>
-              <div className="section">
-                <div
-                  className={classNames(
-                    'title junipero secondary',
-                    '!oak-text-alternate-text-color'
-                  )}
-                >
-                  <Text name="core.components.foldable.sectionsTitle.content">
-                    Content
-                  </Text>
-                </div>
-                <Container
-                  depth={depth + 1}
-                  element={element}
-                  content={element.content as ElementObject[]}
-                  component={component}
-                />
-              </div>
+              <Container
+                depth={depth + 1}
+                element={element}
+                content={element.seeMore}
+                component={component}
+              />
             </div>
-            <Droppable onDrop={onDropElement.bind(null, 'after')}>
-              <div className="drop-zone after" />
-            </Droppable>
+            <div className="section">
+              <div
+                className={classNames(
+                  'title junipero secondary',
+                  '!oak-text-alternate-text-color'
+                )}
+              >
+                <Text name="core.components.foldable.sectionsTitle.seeLess">
+                    Label when expanded
+                </Text>
+              </div>
+              <Container
+                depth={depth + 1}
+                element={element}
+                content={element.seeLess}
+                component={component}
+              />
+            </div>
+            <div className="section">
+              <div
+                className={classNames(
+                  'title junipero secondary',
+                  '!oak-text-alternate-text-color'
+                )}
+              >
+                <Text name="core.components.foldable.sectionsTitle.content">
+                    Content
+                </Text>
+              </div>
+              <Container
+                depth={depth + 1}
+                element={element}
+                content={element.content as ElementObject[]}
+                component={component}
+              />
+            </div>
           </div>
-        )
-      }
+          <Droppable onDrop={onDropElement.bind(null, 'after')}>
+            <div className="drop-zone after" />
+          </Droppable>
+        </div>
+      )}
     </>
   );
 };

--- a/packages/react/lib/components/Foldable/index.tsx
+++ b/packages/react/lib/components/Foldable/index.tsx
@@ -76,7 +76,7 @@ const Foldable = ({
                 )}
               >
                 <Text name="core.components.foldable.sectionsTitle.seeMore">
-                    Label when collapsed
+                  Label when collapsed
                 </Text>
               </div>
               <Container
@@ -94,7 +94,7 @@ const Foldable = ({
                 )}
               >
                 <Text name="core.components.foldable.sectionsTitle.seeLess">
-                    Label when expanded
+                  Label when expanded
                 </Text>
               </div>
               <Container
@@ -112,7 +112,7 @@ const Foldable = ({
                 )}
               >
                 <Text name="core.components.foldable.sectionsTitle.content">
-                    Content
+                  Content
                 </Text>
               </div>
               <Container

--- a/packages/react/lib/components/Row/index.tsx
+++ b/packages/react/lib/components/Row/index.tsx
@@ -13,6 +13,7 @@ import { Droppable, classNames, omit } from '@junipero/react';
 
 import { useBuilder } from '../../hooks';
 import Col from '../Col';
+import Text from '../../Text';
 
 export interface RowProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
@@ -89,46 +90,64 @@ const Row = ({
   }, [builder, element, parent, parentComponent, parentOverride]);
 
   return (
-    <div
-      { ...omit(rest, ['builder', 'component']) }
-      className={classNames(
-        'wrapper',
-        depth % 2 === 0 ? 'even' : 'odd',
-        className,
-      )}
-    >
-      <Droppable onDrop={onDropElement.bind(null, 'before')}>
-        <div className="drop-zone before" />
-      </Droppable>
-      <div
-        className={classNames(
-          'row-content oak-flex oak-flex-wrap oak-w-full oak-gap-2',
-          element.settings?.flexDirection &&
-            'oak-flex-' + element.settings.flexDirection,
-          element.settings?.alignItems
-            ? 'oak-items-' + element.settings.alignItems
-            : /col/.test(element.settings?.flexDirection)
-              ? 'oak-items-stretch' : 'oak-items-start',
-          element.settings?.justifyContent &&
-            'oak-justify-' + element.settings.justifyContent,
+    <>
+      { element.collapsed
+        ? (
+          <div
+            { ...omit(rest, ['builder', 'component']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
+          >
+            <Text name="core.components.row.collapsed">
+              Collapsed row (expand to see inner content)
+            </Text>
+          </div>
+        ) : (
+          <div
+            { ...omit(rest, ['builder', 'component']) }
+            className={classNames(
+              'wrapper',
+              depth % 2 === 0 ? 'even' : 'odd',
+              className,
+            )}
+          >
+            <Droppable onDrop={onDropElement.bind(null, 'before')}>
+              <div className="drop-zone before" />
+            </Droppable>
+            <div
+              className={classNames(
+                'row-content oak-flex oak-flex-wrap oak-w-full oak-gap-2',
+                element.settings?.flexDirection &&
+              'oak-flex-' + element.settings.flexDirection,
+                element.settings?.alignItems
+                  ? 'oak-items-' + element.settings.alignItems
+                  : /col/.test(element.settings?.flexDirection)
+                    ? 'oak-items-stretch' : 'oak-items-start',
+                element.settings?.justifyContent &&
+              'oak-justify-' + element.settings.justifyContent,
+              )}
+            >
+              { element?.cols?.map((col: ElementObject, i: Key) => (
+                <Col
+                  key={i}
+                  depth={depth}
+                  element={col}
+                  parent={element.cols}
+                  onPrepend={onDivide.bind(null, i, true)}
+                  onAppend={onDivide.bind(null, i, false)}
+                  onRemove={onRemoveCol.bind(null, i)}
+                />
+              )) }
+            </div>
+            <Droppable onDrop={onDropElement.bind(null, 'after')}>
+              <div className="drop-zone after" />
+            </Droppable>
+          </div>
         )}
-      >
-        { element?.cols?.map((col: ElementObject, i: Key) => (
-          <Col
-            key={i}
-            depth={depth}
-            element={col}
-            parent={element.cols}
-            onPrepend={onDivide.bind(null, i, true)}
-            onAppend={onDivide.bind(null, i, false)}
-            onRemove={onRemoveCol.bind(null, i)}
-          />
-        )) }
-      </div>
-      <Droppable onDrop={onDropElement.bind(null, 'after')}>
-        <div className="drop-zone after" />
-      </Droppable>
-    </div>
+    </>
   );
 };
 

--- a/packages/react/lib/components/Row/index.tsx
+++ b/packages/react/lib/components/Row/index.tsx
@@ -91,62 +91,48 @@ const Row = ({
 
   return (
     <>
-      { element.collapsed
-        ? (
+      { !element.collapsed && (
+        <div
+          { ...omit(rest, ['builder', 'component']) }
+          className={classNames(
+            'wrapper',
+            depth % 2 === 0 ? 'even' : 'odd',
+            className,
+          )}
+        >
+          <Droppable onDrop={onDropElement.bind(null, 'before')}>
+            <div className="drop-zone before" />
+          </Droppable>
           <div
-            { ...omit(rest, ['builder', 'component']) }
             className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-          >
-            <Text name="core.components.row.collapsed">
-              Collapsed row (expand to see inner content)
-            </Text>
-          </div>
-        ) : (
-          <div
-            { ...omit(rest, ['builder', 'component']) }
-            className={classNames(
-              'wrapper',
-              depth % 2 === 0 ? 'even' : 'odd',
-              className,
-            )}
-          >
-            <Droppable onDrop={onDropElement.bind(null, 'before')}>
-              <div className="drop-zone before" />
-            </Droppable>
-            <div
-              className={classNames(
-                'row-content oak-flex oak-flex-wrap oak-w-full oak-gap-2',
-                element.settings?.flexDirection &&
+              'row-content oak-flex oak-flex-wrap oak-w-full oak-gap-2',
+              element.settings?.flexDirection &&
               'oak-flex-' + element.settings.flexDirection,
-                element.settings?.alignItems
-                  ? 'oak-items-' + element.settings.alignItems
-                  : /col/.test(element.settings?.flexDirection)
-                    ? 'oak-items-stretch' : 'oak-items-start',
-                element.settings?.justifyContent &&
+              element.settings?.alignItems
+                ? 'oak-items-' + element.settings.alignItems
+                : /col/.test(element.settings?.flexDirection)
+                  ? 'oak-items-stretch' : 'oak-items-start',
+              element.settings?.justifyContent &&
               'oak-justify-' + element.settings.justifyContent,
-              )}
-            >
-              { element?.cols?.map((col: ElementObject, i: Key) => (
-                <Col
-                  key={i}
-                  depth={depth}
-                  element={col}
-                  parent={element.cols}
-                  onPrepend={onDivide.bind(null, i, true)}
-                  onAppend={onDivide.bind(null, i, false)}
-                  onRemove={onRemoveCol.bind(null, i)}
-                />
-              )) }
-            </div>
-            <Droppable onDrop={onDropElement.bind(null, 'after')}>
-              <div className="drop-zone after" />
-            </Droppable>
+            )}
+          >
+            { element?.cols?.map((col: ElementObject, i: Key) => (
+              <Col
+                key={i}
+                depth={depth}
+                element={col}
+                parent={element.cols}
+                onPrepend={onDivide.bind(null, i, true)}
+                onAppend={onDivide.bind(null, i, false)}
+                onRemove={onRemoveCol.bind(null, i)}
+              />
+            )) }
           </div>
-        )}
+          <Droppable onDrop={onDropElement.bind(null, 'after')}>
+            <div className="drop-zone after" />
+          </Droppable>
+        </div>
+      )}
     </>
   );
 };

--- a/packages/react/lib/contexts.ts
+++ b/packages/react/lib/contexts.ts
@@ -44,3 +44,11 @@ export declare type EditableFormContextValue = {
 }
 
 export const EditableFormContext = createContext<EditableFormContextValue>({});
+
+export declare interface ElementContextValue {
+  element?: ElementObject;
+  collapsed?: boolean;
+  toggleCollapse?: () => void;
+}
+
+export const ElementContext = createContext<ElementContextValue>({});

--- a/packages/react/lib/hooks.ts
+++ b/packages/react/lib/hooks.ts
@@ -11,7 +11,11 @@ import {
 } from '@junipero/react';
 
 import type { EditableType } from './types';
-import { BuilderContext, EditableFormContext } from './contexts';
+import {
+  BuilderContext,
+  EditableFormContext,
+  ElementContext,
+} from './contexts';
 
 export interface UseRootBuilderProps {
   activeTextSheet?: string;
@@ -151,3 +155,4 @@ export const useRootBuilder = ({
 
 export const useBuilder = () => useContext(BuilderContext);
 export const useEditableForm = () => useContext(EditableFormContext);
+export const useElement = () => useContext(ElementContext);

--- a/packages/react/lib/options.tsx
+++ b/packages/react/lib/options.tsx
@@ -93,7 +93,7 @@ export const collapseOption = (): ReactComponentOptionObject => ({
         name={(
           <Text
             name={`core.tooltips.expand.${collapsed ? 'more' : 'less'}`}
-            default={collapsed ? 'Expand more' : 'Expand less'}
+            default={collapsed ? 'Expand' : 'Collapse'}
           />
         )}
       />

--- a/packages/react/lib/options.tsx
+++ b/packages/react/lib/options.tsx
@@ -1,19 +1,20 @@
 import {
-  ComponentPropsWithoutRef,
-  DragEvent,
-  MouseEvent,
-  MutableRefObject,
-  useEffect,
+  type ComponentPropsWithoutRef,
+  type DragEvent,
+  type MouseEvent,
+  type MutableRefObject,
+  useCallback,
   useRef,
   useState,
 } from 'react';
-import { Draggable, DraggableRef, classNames } from '@junipero/react';
+import { type DraggableRef, Draggable, classNames } from '@junipero/react';
 import type { ComponentOptionObject, ElementObject } from '@oakjs/core';
 
 import type { EditableRef } from './Editable';
-import Option, { OptionRef } from './Option';
+import type { ReactComponentOptionObject } from './types';
+import Option from './Option';
 import Text from './Text';
-import { ReactComponentOptionObject } from './types';
+import { useElement } from './hooks';
 
 export interface DragOptionProps extends ComponentPropsWithoutRef<'a'> {
   element: ElementObject | ElementObject[];
@@ -85,18 +86,13 @@ export const dragOption = (): ComponentOptionObject => ({
 
 export const collapseOption = (): ReactComponentOptionObject => ({
 
-  render: ({ className, element }) => {
-    const [collapsed, setCollapsed] = useState(element.collapsed ?? false);
+  render: ({ className }) => {
+    const { collapsed, toggleCollapse } = useElement();
 
-    useEffect(() => {
-      setCollapsed(element.collapsed);
-    }, [element.collapsed]);
-
-    const onClick = (e: MouseEvent<HTMLElement>) => {
+    const onClick = useCallback((e: MouseEvent<HTMLElement>) => {
       e.preventDefault();
-      element.collapsed = !collapsed;
-      setCollapsed(!collapsed);
-    };
+      toggleCollapse?.();
+    }, [collapsed, toggleCollapse]);
 
     return (
       <Option

--- a/packages/react/lib/options.tsx
+++ b/packages/react/lib/options.tsx
@@ -1,4 +1,12 @@
-import { ComponentPropsWithoutRef, DragEvent, MouseEvent, MutableRefObject, useRef, useState } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  DragEvent,
+  MouseEvent,
+  MutableRefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Draggable, DraggableRef, classNames } from '@junipero/react';
 import type { ComponentOptionObject, ElementObject } from '@oakjs/core';
 
@@ -80,7 +88,12 @@ export const collapseOption = (): ReactComponentOptionObject => ({
   render: ({ className, element }) => {
     const [collapsed, setCollapsed] = useState(element.collapsed ?? false);
 
-    const onClick = () => {
+    useEffect(() => {
+      setCollapsed(element.collapsed);
+    }, [element.collapsed]);
+
+    const onClick = (e: MouseEvent<HTMLElement>) => {
+      e.preventDefault();
       element.collapsed = !collapsed;
       setCollapsed(!collapsed);
     };

--- a/packages/react/lib/options.tsx
+++ b/packages/react/lib/options.tsx
@@ -75,6 +75,32 @@ export const dragOption = (): ComponentOptionObject => ({
   render: (props: DragOptionProps) => <DragOption {...props} />,
 });
 
+export const collapseOption = (): ReactComponentOptionObject => ({
+
+  render: ({ className, element }) => {
+    const [collapsed, setCollapsed] = useState(element.collapsed ?? false);
+
+    const onClick = () => {
+      element.collapsed = !collapsed;
+      setCollapsed(!collapsed);
+    };
+
+    return (
+      <Option
+        onClick={onClick}
+        option={{ icon: collapsed ? 'expand_more' : 'expand_less' }}
+        className={classNames(className)}
+        name={(
+          <Text
+            name={`core.tooltips.expand.${collapsed ? 'more' : 'less'}`}
+            default={collapsed ? 'Expand more' : 'Expand less'}
+          />
+        )}
+      />
+    );
+  },
+});
+
 export const backgroundColorOption = (): ReactComponentOptionObject => ({
   render: ({ element = {} }) =>
     (element.styles?.backgroundColor || element.styles?.backgroundImage) && (


### PR DESCRIPTION
This allow oak user to collapse complex block to have a better comprehension oh his oak content

use case: 

https://github.com/user-attachments/assets/8f0f14d1-d039-459f-b0b1-7ed0c9046f00

