### PR TITLE
✨ feat: allow components (& overrides) to not be usable, editable, copyable, duplicable, draggable & droppable

### DIFF
--- a/packages/core/lib/Builder/index.test.ts.snap
+++ b/packages/core/lib/Builder/index.test.ts.snap
@@ -6,10 +6,12 @@ exports[`Builder should allow to add addons: Components 1`] = `
     "components": [
       Component {
         "construct": undefined,
+        "copyable": true,
         "deserialize": undefined,
         "disallow": [],
         "draggable": true,
         "droppable": true,
+        "duplicable": true,
         "duplicate": undefined,
         "editable": true,
         "getContainers": undefined,

--- a/packages/core/lib/Components/index.test.ts.snap
+++ b/packages/core/lib/Components/index.test.ts.snap
@@ -14,10 +14,12 @@ exports[`Components should allow to add a new group and add components 1`] = `
       "components": [
         Component {
           "construct": undefined,
+          "copyable": true,
           "deserialize": undefined,
           "disallow": [],
           "draggable": true,
           "droppable": true,
+          "duplicable": true,
           "duplicate": undefined,
           "editable": true,
           "getContainers": undefined,

--- a/packages/core/lib/Overrides/index.test.ts.snap
+++ b/packages/core/lib/Overrides/index.test.ts.snap
@@ -14,8 +14,12 @@ exports[`Overrides should allow to add overrides 1`] = `
   },
   ComponentOverride {
     "construct": undefined,
+    "copyable": undefined,
     "deserialize": undefined,
     "disallow": [],
+    "draggable": undefined,
+    "droppable": undefined,
+    "duplicable": undefined,
     "duplicate": undefined,
     "editable": undefined,
     "fields": [],
@@ -29,6 +33,7 @@ exports[`Overrides should allow to add overrides 1`] = `
       "foo",
     ],
     "type": "component",
+    "usable": undefined,
   },
 ]
 `;
@@ -36,8 +41,12 @@ exports[`Overrides should allow to add overrides 1`] = `
 exports[`Overrides should allow to get an override 1`] = `
 ComponentOverride {
   "construct": undefined,
+  "copyable": undefined,
   "deserialize": undefined,
   "disallow": [],
+  "draggable": undefined,
+  "droppable": undefined,
+  "duplicable": undefined,
   "duplicate": undefined,
   "editable": undefined,
   "fields": [],
@@ -51,6 +60,7 @@ ComponentOverride {
     "foo",
   ],
   "type": "component",
+  "usable": undefined,
 }
 `;
 

--- a/packages/core/lib/classes.ts
+++ b/packages/core/lib/classes.ts
@@ -200,6 +200,8 @@ export class ComponentOverride extends Override {
   usable?: boolean;
   duplicable?: boolean;
   copyable?: boolean;
+  draggable?: boolean;
+  droppable?: boolean;
   disallow: string[];
 
   constructor (props: ComponentOverrideObject | ComponentOverride) {
@@ -219,6 +221,8 @@ export class ComponentOverride extends Override {
     this.usable = props.usable;
     this.duplicable = props.duplicable;
     this.copyable = props.copyable;
+    this.draggable = props.draggable;
+    this.droppable = props.droppable;
     this.disallow = props.disallow || [];
   }
 
@@ -235,6 +239,11 @@ export class ComponentOverride extends Override {
       deserialize: this.deserialize,
       priority: this.priority,
       editable: this.editable,
+      usable: this.usable,
+      duplicable: this.duplicable,
+      copyable: this.copyable,
+      draggable: this.draggable,
+      droppable: this.droppable,
       disallow: this.disallow,
     };
   }

--- a/packages/core/lib/classes.ts
+++ b/packages/core/lib/classes.ts
@@ -45,19 +45,24 @@ export class Component {
   duplicate: (elmt?: ElementObject) => ElementObject;
   icon: any;
   getContainers: (element: ElementObject) => ElementObject[][];
-  name: string;
+  name: string | GetTextCallback;
   hasCustomInnerContent: boolean;
   draggable: boolean;
   droppable: boolean;
   usable: boolean;
   editable: boolean;
+  duplicable: boolean;
+  copyable: boolean;
   disallow: any;
   options?: ComponentOption[];
   settings?: ComponentSettingsForm;
-  deserialize: (opts: { builder: Builder }) => ElementObject;
+  deserialize: (
+    element?: ElementObject,
+    opts?: { builder: Builder }
+  ) => ElementObject;
   serialize: Function; //TODO
 
-  constructor (props: any) {
+  constructor (props: ComponentObject) {
     if (!props.id) {
       throw new Error('Component must have an id');
     }
@@ -77,6 +82,8 @@ export class Component {
     this.droppable = props.droppable ?? true;
     this.usable = props.usable ?? true;
     this.editable = props.editable ?? true;
+    this.duplicable = props.duplicable ?? true;
+    this.copyable = props.copyable ?? true;
     this.disallow = props.disallow || [];
     this.serialize = props.serialize;
     this.options = (props.options || []).map((
@@ -189,7 +196,10 @@ export class ComponentOverride extends Override {
   priority: number;
   serialize: Function; //TODO fix it
   getContainers: (element: ElementObject) => ElementObject[][];
-  editable: boolean;
+  editable?: boolean;
+  usable?: boolean;
+  duplicable?: boolean;
+  copyable?: boolean;
   disallow: string[];
 
   constructor (props: ComponentOverrideObject | ComponentOverride) {
@@ -206,6 +216,9 @@ export class ComponentOverride extends Override {
     this.deserialize = props.deserialize;
     this.priority = props.priority;
     this.editable = props.editable;
+    this.usable = props.usable;
+    this.duplicable = props.duplicable;
+    this.copyable = props.copyable;
     this.disallow = props.disallow || [];
   }
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -44,14 +44,20 @@ export declare interface ComponentOverrideObject {
   targets?: string[];
   fields?: ComponentSettingsFieldObject[];
   construct?(opts?: { builder?: Builder }): ElementObject;
-  deserialize?(opts?: { builder?: Builder }): ElementObject;
+  deserialize?(
+    elmt?: ElementObject,
+    opts?: { builder?: Builder }
+  ): ElementObject;
   render?(props?: any, opts?: any): any; // TODO fix this
   sanitize?(elmt?: ElementObject, opts?: {
     builder: Builder;
   }): ElementObject;
   duplicate?(elmt?: ElementObject): ElementObject;
   priority?: number;
+  usable?: boolean;
   editable?: boolean;
+  duplicable?: boolean;
+  copyable?: boolean;
   disallow?: string[];
 }
 
@@ -172,11 +178,16 @@ export declare interface ComponentObject {
   droppable?: boolean;
   usable?: boolean;
   editable?: boolean;
+  duplicable?: boolean;
+  copyable?: boolean;
   options?: ComponentOptionObject[];
   settings?: ComponentSettingsFormObject | ComponentSettingsTabObject;
   disallow?: string[];
   render?(props?: any): any;
-  deserialize?: Function;
+  deserialize?: (
+    elmt?: ElementObject,
+    opts?: { builder: Builder }
+  ) => ElementObject;
   serialize?: Function;
   sanitize?(
     element: ElementObject, { builder }: { builder: Builder }

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -58,6 +58,8 @@ export declare interface ComponentOverrideObject {
   editable?: boolean;
   duplicable?: boolean;
   copyable?: boolean;
+  draggable?: boolean;
+  droppable?: boolean;
   disallow?: string[];
 }
 

--- a/packages/react/lib/Catalogue/index.tsx
+++ b/packages/react/lib/Catalogue/index.tsx
@@ -167,15 +167,21 @@ const Catalogue = forwardRef<CatalogueRef, CatalogueProps>(({
 
   const groups = useMemo(() => (
     availableGroups
-      .filter(g => g.usable !== false)
+      .filter(g =>
+        g.usable !== false &&
+        (builder?.getOverride('component', g.id) as ComponentOverride)
+          ?.usable !== false
+      )
       .map(g => ({
         ...g,
         components: g.components.filter((c: ComponentObject) => (
           c.usable !== false &&
-            (!component || !component.disallow ||
-              !component.disallow.includes(c.id)) &&
-            (!override || !override.disallow ||
-              !override.disallow.includes(c.id))
+          (builder?.getOverride('component', c.id) as ComponentOverride)
+            ?.usable !== false &&
+          (!component || !component.disallow ||
+            !component.disallow.includes(c.id)) &&
+          (!override || !override.disallow ||
+            !override.disallow.includes(c.id))
         )),
       }))
       .filter(g => g.components.length)

--- a/packages/react/lib/Container/index.tsx
+++ b/packages/react/lib/Container/index.tsx
@@ -85,7 +85,13 @@ const Container = ({
   };
 
   return (
-    <Droppable disabled={content.length > 0} onDrop={onDrop}>
+    <Droppable
+      disabled={
+        content.length > 0 ||
+        (override?.droppable ?? component?.droppable) === false
+      }
+      onDrop={onDrop}
+    >
       <div
         { ...rest }
         className={classNames(

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -131,6 +131,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
       renderer={override?.render || component?.render}
       element={element}
       component={component}
+      override={override}
       parentComponent={parentComponent}
       parent={parent}
       builder={builder}
@@ -141,19 +142,11 @@ const Element = forwardRef<ElementRef, ElementProps>(({
 
   return (
     <ElementContext.Provider value={getElementContext()}>
-      <Droppable
-        ref={innerRef}
-        disabled={
-          component?.droppable === false ||
-          override?.droppable === false
-        }
-        onDrop={onDrop_}
-      >
+      <Droppable ref={innerRef} onDrop={onDrop_}>
         <Draggable
           data={element}
           disabled={
-            component?.draggable === false ||
-            override?.draggable === false ||
+            (override?.draggable ?? component?.draggable) === false ||
             editableOpened
           }
         >

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -71,7 +71,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
     builder.getComponent(element?.type)
   ), [element?.type, addons]);
   const override = useMemo(() => (
-    builder.getOverride('component', element?.type)
+    builder.getOverride('component', element?.type) as ComponentOverride
   ), [element?.type, builder, addons]);
   const parentOverride = useMemo(() => (
     builder.getOverride('component', parentComponent?.id) as ComponentOverride
@@ -128,10 +128,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
 
   const rendered = (
     <DynamicComponent
-      renderer={
-        (override as ComponentOverrideObject)?.render ||
-        component?.render
-      }
+      renderer={override?.render || component?.render}
       element={element}
       component={component}
       parentComponent={parentComponent}
@@ -146,12 +143,19 @@ const Element = forwardRef<ElementRef, ElementProps>(({
     <ElementContext.Provider value={getElementContext()}>
       <Droppable
         ref={innerRef}
-        disabled={component?.droppable === false}
+        disabled={
+          component?.droppable === false ||
+          override?.droppable === false
+        }
         onDrop={onDrop_}
       >
         <Draggable
           data={element}
-          disabled={component?.draggable === false || editableOpened}
+          disabled={
+            component?.draggable === false ||
+            override?.draggable === false ||
+            editableOpened
+          }
         >
           <div
             className={classNames(
@@ -207,7 +211,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                     <DisplayableSettings
                       element={element}
                       component={component}
-                      override={override as ComponentOverrideObject}
+                      override={override}
                     />
                   </div>
                 </div>
@@ -243,9 +247,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                 onClick={onDelete_}
                 name={<Text name="core.tooltips.remove">Remove</Text> }
               />
-              { ((override as ComponentOverrideObject)?.duplicable ??
-                component?.duplicable
-              ) && (
+              { (override?.duplicable ?? component?.duplicable) && (
                 <Option
                   option={{ icon: 'copy' }}
                   className="duplicate"
@@ -255,9 +257,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                   )}
                 />
               ) }
-              { ((override as ComponentOverrideObject)?.copyable ??
-                component?.copyable
-              ) && (
+              { (override?.copyable ?? component?.copyable) && (
                 <Option
                   option={{ icon: 'copy_file' }}
                   className="copy"
@@ -280,9 +280,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                   index={i}
                 />
               )) }
-              { ((override as ComponentOverrideObject)?.editable ??
-                component?.editable
-              ) && (
+              { (override?.editable ?? component?.editable) && (
                 <Editable
                   element={element}
                   component={component}

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -243,20 +243,28 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                 onClick={onDelete_}
                 name={<Text name="core.tooltips.remove">Remove</Text> }
               />
-              <Option
-                option={{ icon: 'copy' }}
-                className="duplicate"
-                onClick={onDuplicate_}
-                name={(
-                  <Text name="core.tooltips.duplicate">Duplicate</Text>
-                )}
-              />
-              <Option
-                option={{ icon: 'copy_file' }}
-                className="copy"
-                onClick={onCopy_}
-                name={<Text name="core.tooltips.copy">Copy</Text>}
-              />
+              { ((override as ComponentOverrideObject)?.duplicable ??
+                component?.duplicable
+              ) && (
+                <Option
+                  option={{ icon: 'copy' }}
+                  className="duplicate"
+                  onClick={onDuplicate_}
+                  name={(
+                    <Text name="core.tooltips.duplicate">Duplicate</Text>
+                  )}
+                />
+              ) }
+              { ((override as ComponentOverrideObject)?.copyable ??
+                component?.copyable
+              ) && (
+                <Option
+                  option={{ icon: 'copy_file' }}
+                  className="copy"
+                  onClick={onCopy_}
+                  name={<Text name="core.tooltips.copy">Copy</Text>}
+                />
+              ) }
               { (component?.options || []).map((o, i) => (
                 <DynamicComponent
                   renderer={o.render}
@@ -271,7 +279,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
                   builder={builder}
                   index={i}
                 />
-              ))}
+              )) }
               { ((override as ComponentOverrideObject)?.editable ??
                 component?.editable
               ) && (

--- a/packages/react/lib/components/Col/index.tsx
+++ b/packages/react/lib/components/Col/index.tsx
@@ -25,6 +25,8 @@ import Text from '../../Text';
 export interface ColProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
   parent: ElementObject[];
+  parentComponent?: ComponentObject;
+  parentOverride?: ComponentOverrideObject;
   depth?: number;
   onPrepend?: () => void;
   onAppend?: () => void;
@@ -34,6 +36,8 @@ export interface ColProps extends ComponentPropsWithoutRef<'div'> {
 const Col = ({
   element,
   className,
+  parentComponent,
+  parentOverride,
   parent = [],
   depth = 0,
   onPrepend,
@@ -149,7 +153,18 @@ const Col = ({
         </a>
       </Tooltip>
 
-      <Droppable disabled={element.content.length > 0} onDrop={onDrop_}>
+      <Droppable
+        disabled={
+          element.content.length > 0 ||
+          (
+            override?.droppable ??
+            component?.droppable ??
+            parentComponent?.droppable ??
+            parentOverride?.droppable
+          ) === false
+        }
+        onDrop={onDrop_}
+      >
         <div
           className="col-inner oak-flex-auto oak-flex oak-flex-col oak-gap-2"
         >
@@ -283,10 +298,7 @@ const Col = ({
               }}
             />
           )}
-          { (
-            (override as ComponentOverrideObject)?.editable ??
-            component.editable
-          ) && (
+          { (override?.editable ?? component.editable) && (
             <Editable
               ref={editableRef}
               element={element}

--- a/packages/react/lib/components/Row/index.tsx
+++ b/packages/react/lib/components/Row/index.tsx
@@ -1,6 +1,7 @@
 import type {
   ComponentObject,
   ComponentOverride,
+  ComponentOverrideObject,
   ElementObject,
 } from '@oakjs/core';
 import {
@@ -13,17 +14,20 @@ import { Droppable, classNames, omit } from '@junipero/react';
 
 import { useBuilder } from '../../hooks';
 import Col from '../Col';
-import Text from '../../Text';
 
 export interface RowProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
   parent: Array<ElementObject>;
   parentComponent: ComponentObject;
+  component?: ComponentObject;
+  override?: ComponentOverrideObject;
   depth?: number;
 }
 
 const Row = ({
   element,
+  component,
+  override,
   parent,
   parentComponent,
   className,
@@ -122,6 +126,8 @@ const Row = ({
                 depth={depth}
                 element={col}
                 parent={element.cols}
+                parentComponent={component}
+                parentOverride={override}
                 onPrepend={onDivide.bind(null, i, true)}
                 onAppend={onDivide.bind(null, i, false)}
                 onRemove={onRemoveCol.bind(null, i)}

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -526,3 +526,22 @@ export const withImageUpdload = () => (
     onChange={action('change')}
   />
 );
+
+export const withNonDuplicableOrCopyableComponents = () => (
+  <Builder
+    addons={[baseAddon(), {
+      overrides: [{
+        type: 'component',
+        targets: ['title'],
+        editable: false,
+        usable: false,
+        duplicable: false,
+        copyable: false,
+        draggable: false,
+      }],
+    }]}
+    value={baseContent}
+    options={{ debug: true }}
+    onChange={action('change')}
+  />
+);

--- a/packages/theme/lib/Element.sass
+++ b/packages/theme/lib/Element.sass
@@ -109,7 +109,7 @@
 
     &.opened
       visibility: visible
-  
+
   .options.oak-has-inner-content
     position: absolute
     bottom: 100%
@@ -126,11 +126,13 @@
       &:last-child
         border-radius: 0 5px 0 0
 
+      &:first-child:last-child
+        border-radius: 5px
+
     &.dragging
       .drop-zone
         display: none
         height: 0
-
 
   .debug
     position: absolute

--- a/packages/theme/lib/Option.sass
+++ b/packages/theme/lib/Option.sass
@@ -16,6 +16,9 @@
   &:last-child
     border-radius: 0 5px 5px 0
 
+  &:first-child:last-child
+    border-radius: 5px
+
   .icon
     color: var(--option-text-color)
 


### PR DESCRIPTION
`usable` -> not available in catalogue but still displayed inside the builder if it exists to avoid resolving to `Unknown`
`droppable` -> cannot drop children inside containers, but as it's too complicated to do it recursively, can still drop before/after
Other options are pretty self explanatory.

<img width="2206" alt="Capture d’écran 2024-10-14 à 17 14 03" src="https://github.com/user-attachments/assets/fcbef769-6707-424d-90a1-f4f5115423bf">

<img width="565" alt="Capture d’écran 2024-10-14 à 17 13 15" src="https://github.com/user-attachments/assets/b39e3524-6c29-4ae1-bf6d-7d6768c2b3d0">
