### PR TITLE
🐛 fix: correctly handle drag & drop 

### DIFF
--- a/packages/react/lib/Container/index.tsx
+++ b/packages/react/lib/Container/index.tsx
@@ -17,12 +17,14 @@ export declare interface ContainerProps
   content?: Array<ElementObject>;
   component?: ComponentObject | Component;
   depth?: number;
+  droppable?: boolean;
 }
 
 const Container = ({
   element,
   component,
   className,
+  droppable,
   content = [],
   depth = 0,
   ...rest
@@ -52,7 +54,9 @@ const Container = ({
     });
   };
 
-  const onDrop = useCallback((data: ElementObject) => {
+  const onDrop = useCallback((
+    data: ElementObject,
+  ) => {
     if (
       component?.disallow?.includes?.(data.type) ||
       override?.disallow?.includes?.(data.type)
@@ -88,7 +92,7 @@ const Container = ({
     <Droppable
       disabled={
         content.length > 0 ||
-        (override?.droppable ?? component?.droppable) === false
+        (override?.droppable ?? droppable ?? component?.droppable) === false
       }
       onDrop={onDrop}
     >

--- a/packages/react/lib/Container/index.tsx
+++ b/packages/react/lib/Container/index.tsx
@@ -24,7 +24,7 @@ const Container = ({
   element,
   component,
   className,
-  droppable,
+  droppable = true,
   content = [],
   depth = 0,
   ...rest
@@ -92,7 +92,7 @@ const Container = ({
     <Droppable
       disabled={
         content.length > 0 ||
-        (override?.droppable ?? droppable ?? component?.droppable) === false
+        (override?.droppable ?? droppable) === false
       }
       onDrop={onDrop}
     >

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -148,8 +148,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
         ref={innerRef}
         onDrop={onDrop_}
         disabled={
-          component?.droppable === false ||
-          override?.droppable === false
+          (override?.droppable ?? component?.droppable) === false
         }
       >
         <Draggable

--- a/packages/react/lib/Element/index.tsx
+++ b/packages/react/lib/Element/index.tsx
@@ -1,7 +1,6 @@
 import type {
   ComponentObject,
   ComponentOverride,
-  ComponentOverrideObject,
   ElementObject,
 } from '@oakjs/core';
 import {
@@ -54,7 +53,7 @@ const Element = forwardRef<ElementRef, ElementProps>(({
   parentComponent,
   className,
   depth = 0,
-}, ref) => {
+}: ElementProps, ref) => {
   const innerRef = useRef<DroppableRef>();
   const editableRef = useRef<EditableRef>();
   const modalRef = useRef<ModalRef>();
@@ -95,7 +94,10 @@ const Element = forwardRef<ElementRef, ElementProps>(({
     builder.duplicateElement(element, { parent });
   };
 
-  const onDrop_ = useCallback((data: any, position: ('before' | 'after')) => {
+  const onDrop_ = useCallback((
+    data: ElementObject,
+    position: 'before' | 'after',
+  ) => {
     if (
       parentComponent?.disallow?.includes?.(data.type) ||
       parentOverride?.disallow?.includes?.(data.type)
@@ -142,7 +144,14 @@ const Element = forwardRef<ElementRef, ElementProps>(({
 
   return (
     <ElementContext.Provider value={getElementContext()}>
-      <Droppable ref={innerRef} onDrop={onDrop_}>
+      <Droppable
+        ref={innerRef}
+        onDrop={onDrop_}
+        disabled={
+          component?.droppable === false ||
+          override?.droppable === false
+        }
+      >
         <Draggable
           data={element}
           disabled={

--- a/packages/react/lib/components/Clickable/index.tsx
+++ b/packages/react/lib/components/Clickable/index.tsx
@@ -37,16 +37,16 @@ const Clickable = ({
 
   const onDropElement = useCallback((
     position: 'before' | 'after',
-    sibling: ElementObject
+    data: ElementObject,
   ) => {
     if (
-      parentComponent?.disallow?.includes?.(sibling.type) ||
-      parentOverride?.disallow?.includes?.(sibling.type)
+      parentComponent?.disallow?.includes?.(data.type) ||
+      parentOverride?.disallow?.includes?.(data.type)
     ) {
       return;
     }
 
-    builder.moveElement(sibling, element, { parent, position });
+    builder.moveElement?.(data, element, { parent, position });
   }, [
     builder, element, parent, component, override, parentComponent,
     parentOverride,
@@ -84,6 +84,7 @@ const Clickable = ({
                 element={element}
                 content={element.content as ElementObject[]}
                 component={component}
+                droppable={true}
               />
             </div>
           </div>

--- a/packages/react/lib/components/Clickable/index.tsx
+++ b/packages/react/lib/components/Clickable/index.tsx
@@ -84,7 +84,6 @@ const Clickable = ({
                 element={element}
                 content={element.content as ElementObject[]}
                 component={component}
-                droppable={true}
               />
             </div>
           </div>

--- a/packages/react/lib/components/Col/index.tsx
+++ b/packages/react/lib/components/Col/index.tsx
@@ -161,8 +161,8 @@ const Col = ({
           (
             override?.droppable ??
             component?.droppable ??
-            parentComponent?.droppable ??
-            parentOverride?.droppable
+            parentOverride?.droppable ??
+            parentComponent?.droppable
           ) === false
         }
         onDrop={onDrop_}

--- a/packages/react/lib/components/Col/index.tsx
+++ b/packages/react/lib/components/Col/index.tsx
@@ -89,7 +89,9 @@ const Col = ({
     });
   };
 
-  const onDrop_ = useCallback((data: ComponentObject) => {
+  const onDrop_ = useCallback((
+    data: ElementObject,
+  ) => {
     if (
       component?.disallow?.includes?.(data.type) ||
       override?.disallow?.includes?.(data.type)

--- a/packages/react/lib/components/Foldable/index.tsx
+++ b/packages/react/lib/components/Foldable/index.tsx
@@ -83,7 +83,6 @@ const Foldable = ({
                 element={element}
                 content={element.seeMore}
                 component={component}
-                droppable={true}
               />
             </div>
             <div className="section">
@@ -102,7 +101,6 @@ const Foldable = ({
                 element={element}
                 content={element.seeLess}
                 component={component}
-                droppable={true}
               />
             </div>
             <div className="section">
@@ -121,7 +119,6 @@ const Foldable = ({
                 element={element}
                 content={element.content as ElementObject[]}
                 component={component}
-                droppable={true}
               />
             </div>
           </div>

--- a/packages/react/lib/components/Foldable/index.tsx
+++ b/packages/react/lib/components/Foldable/index.tsx
@@ -37,16 +37,16 @@ const Foldable = ({
 
   const onDropElement = useCallback((
     position: 'before' | 'after',
-    sibling: ElementObject
+    data: ElementObject,
   ) => {
     if (
-      parentComponent?.disallow?.includes?.(sibling.type) ||
-      parentOverride?.disallow?.includes?.(sibling.type)
+      parentComponent?.disallow?.includes?.(data.type) ||
+      parentOverride?.disallow?.includes?.(data.type)
     ) {
       return;
     }
 
-    builder.moveElement(sibling, element, { parent, position });
+    builder.moveElement?.(data, element, { parent, position });
   }, [
     builder, element, parent, component, override, parentComponent,
     parentOverride,
@@ -71,8 +71,7 @@ const Foldable = ({
             <div className="section">
               <div
                 className={classNames(
-                  'title junipero secondary',
-                  '!oak-text-alternate-text-color'
+                  'title junipero secondary !oak-text-alternate-text-color'
                 )}
               >
                 <Text name="core.components.foldable.sectionsTitle.seeMore">
@@ -84,6 +83,7 @@ const Foldable = ({
                 element={element}
                 content={element.seeMore}
                 component={component}
+                droppable={true}
               />
             </div>
             <div className="section">
@@ -102,6 +102,7 @@ const Foldable = ({
                 element={element}
                 content={element.seeLess}
                 component={component}
+                droppable={true}
               />
             </div>
             <div className="section">
@@ -120,6 +121,7 @@ const Foldable = ({
                 element={element}
                 content={element.content as ElementObject[]}
                 component={component}
+                droppable={true}
               />
             </div>
           </div>

--- a/packages/react/lib/components/Row/index.tsx
+++ b/packages/react/lib/components/Row/index.tsx
@@ -81,16 +81,16 @@ const Row = ({
 
   const onDropElement = useCallback((
     position: 'before' | 'after',
-    sibling: ElementObject
+    data: ElementObject,
   ) => {
     if (
-      parentComponent?.disallow?.includes?.(sibling.type) ||
-      parentOverride?.disallow?.includes?.(sibling.type)
+      parentComponent?.disallow?.includes?.(data.type) ||
+      parentOverride?.disallow?.includes?.(data.type)
     ) {
       return;
     }
 
-    builder.moveElement(sibling, element, { parent, position });
+    builder.moveElement?.(data, element, { parent, position });
   }, [builder, element, parent, parentComponent, parentOverride]);
 
   return (


### PR DESCRIPTION
Drag & drop has been utterly fucked since 3.9.0 because of various false flags:
- `Element` (which is the basis of all elements in the builder, even container-able components like row) was not preventing drops when it was disabled, because the check has been moved to the parent component: in theory it works, except for pre-disabled components (e.g anything with a container—row, clickable, foldable, ...) that need their underlying element to be non-droppable
- `Element`'s droppable not being disabled correctly, dragging/dropping an element inside a container-able would trigger `onDrop` on both the moved element AND the parent, resulting on the element being removed from its parent and moved above

I brought back the `disabled` prop on `Element`'s droppable, and moved the check for container-able on the deeper `Container` component, still with the ability to disable it completely from addons & overrides.

ℹ️ I initially didn't set a default value on `Container`'s `droppable` prop to avoid forcing custom components having `droppable: false` because of deeper `Containers` (like row) to explicitly provide `droppable={true}`, but did have to add it everywhere, so I reverted and set `Container`'s `droppable` to `true` by default, and you have to explicitly pass `false` if needed (which doesn't require any API adaptation).