### PR TITLE
🐛 fix(react): allow to use polyfills to parse html

### DIFF
--- a/packages/react/lib/Builder/index.tsx
+++ b/packages/react/lib/Builder/index.tsx
@@ -49,6 +49,10 @@ export declare interface BuilderProps extends SpecialComponentPropsWithoutRef {
   topHistoryButtonsContainer?: string | HTMLElement | DocumentFragment;
   topHistoryButtonsEnabled?: boolean;
   value?: Array<ElementObject>;
+  polyfills?: {
+    DOMParser: typeof DOMParser;
+    XMLSerializer: typeof XMLSerializer;
+  };
   onChange?(content: Array<ElementObject>): void;
   onImageUpload?(event: FormEvent, opts: {
     element?: ElementObject;
@@ -66,6 +70,7 @@ const Builder = forwardRef<BuilderRef, BuilderProps>(({
   onImageUpload,
   topHistoryButtonsContainer,
   bottomHistoryButtonsContainer,
+  polyfills,
   historyEnabled = true,
   topHistoryButtonsEnabled = true,
   bottomHistoryButtonsEnabled = true,
@@ -107,7 +112,11 @@ const Builder = forwardRef<BuilderRef, BuilderProps>(({
     rootRef: innerRef,
     floatingsRef,
     editableType,
-  }), [builder, content, addons, rootBoundary, onImageUpload, editableType]);
+    polyfills,
+  }), [
+    builder, content, addons, rootBoundary, onImageUpload, polyfills,
+    editableType,
+  ]);
 
   const onAppend = (component: ComponentObject) => {
     catalogueRef.current?.close();

--- a/packages/react/lib/components/Button/index.tsx
+++ b/packages/react/lib/components/Button/index.tsx
@@ -1,8 +1,9 @@
-import type { ComponentPropsWithoutRef } from 'react';
 import type { ElementObject } from '@oakjs/core';
+import { type ComponentPropsWithoutRef, useContext } from 'react';
 import { Button, classNames } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
+import { BuilderContext, type BuilderContextValue } from '../../contexts';
 
 export interface ButtonProps extends ComponentPropsWithoutRef<typeof Button> {
   element: ElementObject;
@@ -11,17 +12,28 @@ export interface ButtonProps extends ComponentPropsWithoutRef<typeof Button> {
 const Button_ = ({
   element,
   className,
-}: ButtonProps) => !element.content ? null : (
-  <Button
-    className={classNames(
-      'default !oak-pointer-events-none sanitize-html',
-      className
-    )}
-    dangerouslySetInnerHTML={
-      { __html: sanitizeHTML(element.content as string) }
-    }
-  />
-);
+}: ButtonProps) => {
+  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+
+  if (!element.content) {
+    return null;
+  }
+
+  return (
+    <Button
+      className={classNames(
+        'default !oak-pointer-events-none sanitize-html',
+        className
+      )}
+      dangerouslySetInnerHTML={
+        { __html: sanitizeHTML(element.content as string, {
+          parser: polyfills?.DOMParser,
+          serializer: polyfills?.XMLSerializer,
+        }) }
+      }
+    />
+  );
+};
 
 Button_.displayName = 'Button';
 

--- a/packages/react/lib/components/Button/index.tsx
+++ b/packages/react/lib/components/Button/index.tsx
@@ -1,9 +1,9 @@
+import type { ComponentPropsWithoutRef } from 'react';
 import type { ElementObject } from '@oakjs/core';
-import { type ComponentPropsWithoutRef, useContext } from 'react';
 import { Button, classNames } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
-import { BuilderContext, type BuilderContextValue } from '../../contexts';
+import { useBuilder } from '../../hooks';
 
 export interface ButtonProps extends ComponentPropsWithoutRef<typeof Button> {
   element: ElementObject;
@@ -13,7 +13,7 @@ const Button_ = ({
   element,
   className,
 }: ButtonProps) => {
-  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+  const { polyfills } = useBuilder();
 
   if (!element.content) {
     return null;

--- a/packages/react/lib/components/Text/index.tsx
+++ b/packages/react/lib/components/Text/index.tsx
@@ -1,9 +1,9 @@
-import { type ComponentPropsWithoutRef, useContext } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 import type { ElementObject } from '@oakjs/core';
 import { classNames } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
-import { BuilderContext, type BuilderContextValue } from '../../contexts';
+import { useBuilder } from '../../hooks';
 
 export interface TextComponentProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
@@ -13,7 +13,7 @@ const Text = ({
   element,
   className,
 }: TextComponentProps) => {
-  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+  const { polyfills } = useBuilder();
 
   if (!element.content) {
     return null;

--- a/packages/react/lib/components/Text/index.tsx
+++ b/packages/react/lib/components/Text/index.tsx
@@ -1,8 +1,9 @@
-import type { ComponentPropsWithoutRef } from 'react';
+import { type ComponentPropsWithoutRef, useContext } from 'react';
 import type { ElementObject } from '@oakjs/core';
 import { classNames } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
+import { BuilderContext, type BuilderContextValue } from '../../contexts';
 
 export interface TextComponentProps extends ComponentPropsWithoutRef<'div'> {
   element: ElementObject;
@@ -11,14 +12,25 @@ export interface TextComponentProps extends ComponentPropsWithoutRef<'div'> {
 const Text = ({
   element,
   className,
-}: TextComponentProps) => !element.content ? null : (
-  <div
-    className={classNames('junipero sanitize-html', className)}
-    dangerouslySetInnerHTML={
-      { __html: sanitizeHTML(element.content as string) }
-    }
-  />
-);
+}: TextComponentProps) => {
+  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+
+  if (!element.content) {
+    return null;
+  }
+
+  return (
+    <div
+      className={classNames('junipero sanitize-html', className)}
+      dangerouslySetInnerHTML={
+        { __html: sanitizeHTML(element.content as string, {
+          parser: polyfills?.DOMParser,
+          serializer: polyfills?.XMLSerializer,
+        }) }
+      }
+    />
+  );
+};
 
 Text.displayName = 'TextComponent';
 

--- a/packages/react/lib/components/Title/index.tsx
+++ b/packages/react/lib/components/Title/index.tsx
@@ -1,16 +1,20 @@
 import type { ElementObject } from '@oakjs/core';
+import { useContext } from 'react';
 import {
   type SpecialComponentPropsWithoutRef,
   classNames,
 } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
+import { BuilderContext, type BuilderContextValue } from '../../contexts';
 
 export interface TitleProps extends SpecialComponentPropsWithoutRef {
   element: ElementObject;
 }
 
 const Title = ({ element, className }: TitleProps) => {
+  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+
   const Tag = element.headingLevel || 'h1';
   const sizes: { [key: string]: string } = {
     h1: '!oak-text-4xl',
@@ -21,7 +25,9 @@ const Title = ({ element, className }: TitleProps) => {
     h6: '!oak-text-md',
   };
 
-  if (!element.content) return null;
+  if (!element.content) {
+    return null;
+  }
 
   return (
     <Tag
@@ -31,7 +37,10 @@ const Title = ({ element, className }: TitleProps) => {
         className
       )}
       dangerouslySetInnerHTML={
-        { __html: sanitizeHTML(element.content as string) }
+        { __html: sanitizeHTML(element.content as string, {
+          parser: polyfills?.DOMParser,
+          serializer: polyfills?.XMLSerializer,
+        }) }
       }
     />
   );

--- a/packages/react/lib/components/Title/index.tsx
+++ b/packages/react/lib/components/Title/index.tsx
@@ -1,19 +1,18 @@
 import type { ElementObject } from '@oakjs/core';
-import { useContext } from 'react';
 import {
   type SpecialComponentPropsWithoutRef,
   classNames,
 } from '@junipero/react';
 
 import { sanitizeHTML } from '../../utils';
-import { BuilderContext, type BuilderContextValue } from '../../contexts';
+import { useBuilder } from '../../hooks';
 
 export interface TitleProps extends SpecialComponentPropsWithoutRef {
   element: ElementObject;
 }
 
 const Title = ({ element, className }: TitleProps) => {
-  const { polyfills } = useContext<BuilderContextValue>(BuilderContext);
+  const { polyfills } = useBuilder();
 
   const Tag = element.headingLevel || 'h1';
   const sizes: { [key: string]: string } = {

--- a/packages/react/lib/contexts.ts
+++ b/packages/react/lib/contexts.ts
@@ -33,6 +33,10 @@ export declare type BuilderContextValue = {
   rootRef?: MutableRefObject<HTMLDivElement>;
   floatingsRef?: MutableRefObject<HTMLDivElement>;
   editableType?: EditableType;
+  polyfills?: {
+    DOMParser: typeof DOMParser;
+    XMLSerializer: typeof XMLSerializer;
+  };
 };
 
 export const BuilderContext = createContext<BuilderContextValue>({});

--- a/packages/react/lib/hooks.ts
+++ b/packages/react/lib/hooks.ts
@@ -12,6 +12,7 @@ import {
 
 import type { EditableType } from './types';
 import {
+  type BuilderContextValue,
   BuilderContext,
   EditableFormContext,
   ElementContext,
@@ -153,6 +154,6 @@ export const useRootBuilder = ({
   return { builder, ...state };
 };
 
-export const useBuilder = () => useContext(BuilderContext);
+export const useBuilder = () => useContext<BuilderContextValue>(BuilderContext);
 export const useEditableForm = () => useContext(EditableFormContext);
 export const useElement = () => useContext(ElementContext);

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -1,23 +1,30 @@
 export const copyToClipboard = (value: string) =>
   globalThis.navigator.clipboard.writeText(value);
 
-export const sanitizeHTML = (content: string) => {
+export const sanitizeHTML = (content: string, opts?: {
+  parser?: typeof DOMParser;
+  serializer?: typeof XMLSerializer;
+}) => {
   try {
-    const parsed = new DOMParser().parseFromString(content, 'text/html');
+    const parsed = new (opts?.parser || DOMParser)()
+      .parseFromString(content, 'text/html');
 
     // Remove script & style tags
-    parsed
-      .querySelectorAll('script, style, iframe, object, video, audio')
-      .forEach(item => item.parentNode.removeChild(item));
-
-    // Disable all links
-    parsed.querySelectorAll('a[href]').forEach(item => {
-      item.removeAttribute('href');
-      item.removeAttribute('target');
-      item.setAttribute('role', 'link');
+    ['script', 'style', 'iframe', 'object', 'video', 'audio'].forEach(t => {
+      Array.from(parsed.getElementsByTagName(t))
+        .forEach(item => item.parentNode.removeChild(item));
     });
 
-    return parsed.body.innerHTML;
+    // Disable all links
+    Array.from(parsed.getElementsByTagName('a')).forEach(item => {
+      if (item.hasAttribute('href')) {
+        item.removeAttribute('href');
+        item.removeAttribute('target');
+        item.setAttribute('role', 'link');
+      }
+    });
+
+    return new (opts?.serializer || XMLSerializer)().serializeToString(parsed);
   } catch (e) {
     console.error(e);
 


### PR DESCRIPTION
`DOMParser` is a client-side DOM level 1 class that doesn't exist in a server side environment. This creates hydratation errors as the sanitized html would be `''` on the server, but the right value on the client.
To prevent this, I added the ability to pass spec-compatible DOMParser & XMLSerializer polyfills to the builder (for example `@xmldom/xmldom` can be used on both client & server), and adapted the code a bit to not use `querySelector` that was not implemented in most of the xml-compatible parsers.