### PR TITLE
🐛 fix(react): fix overrides

### DIFF
--- a/packages/react/lib/Editable/Field.tsx
+++ b/packages/react/lib/Editable/Field.tsx
@@ -58,8 +58,8 @@ const Field = ({
   const setting = useMemo(() => assignDefined<typeof fieldSetting>(
     { type: fieldSetting.type },
     fieldSetting,
-    omit(overrides.settings?.toObject?.() || overrides.settings || {}, ['key']),
     omit(overrides.field?.toObject?.() || overrides.field || {}, ['key']),
+    omit(overrides.settings?.toObject?.() || overrides.settings || {}, ['key']),
   ), [fieldSetting, overrides, addons]);
 
   const fieldProps = {
@@ -77,6 +77,7 @@ const Field = ({
       : onChange.bind(null, setting.key),
     ...field?.props,
     ...(overrides.field as FieldOverride)?.props,
+    ...(overrides.settings as FieldOverride)?.props,
   };
 
   if (setting.condition &&

--- a/packages/react/lib/Editable/Tab.tsx
+++ b/packages/react/lib/Editable/Tab.tsx
@@ -21,6 +21,7 @@ import type { EditableRef } from './index';
 import { useBuilder } from '../hooks';
 import Setting from './Setting';
 import SettingsGroup from './SettingsGroup';
+import { areArraysEqual } from '../utils';
 
 export interface TabProps extends ComponentPropsWithoutRef<'div'> {
   tab: ComponentSettingsTabObject | ComponentSettingsFieldObject;
@@ -83,7 +84,11 @@ const Tab = ({
         .concat(componentOverride?.fields?.filter(f =>
           !component.settings?.fields?.find(s =>
             s.type !== 'tab' &&
-            (s as ComponentSettingsFieldObject).key === f.key
+            ((s as ComponentSettingsFieldObject).key === f.key ||
+            areArraysEqual(
+              (s as ComponentSettingsFieldObject).key as string[],
+              f.key as string[]
+            ))
           )
         ) || [])
         .filter((field: ComponentSettingsFieldObject) =>

--- a/packages/react/lib/Editable/Tab.tsx
+++ b/packages/react/lib/Editable/Tab.tsx
@@ -21,7 +21,6 @@ import type { EditableRef } from './index';
 import { useBuilder } from '../hooks';
 import Setting from './Setting';
 import SettingsGroup from './SettingsGroup';
-import { areArraysEqual } from '../utils';
 
 export interface TabProps extends ComponentPropsWithoutRef<'div'> {
   tab: ComponentSettingsTabObject | ComponentSettingsFieldObject;
@@ -85,10 +84,8 @@ const Tab = ({
           !component.settings?.fields?.find(s =>
             s.type !== 'tab' &&
             ((s as ComponentSettingsFieldObject).key === f.key ||
-            areArraysEqual(
-              (s as ComponentSettingsFieldObject).key as string[],
-              f.key as string[]
-            ))
+            [].concat((s as ComponentSettingsFieldObject).key)
+              .some(k => [].concat(f.key).includes(k)))
           )
         ) || [])
         .filter((field: ComponentSettingsFieldObject) =>

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -9,6 +9,7 @@ import { action } from '@storybook/addon-actions';
 
 import Builder, { type BuilderRef } from './Builder';
 import { baseAddon } from './addons';
+import { ImageField } from './fields';
 
 export default { title: 'React/Builder' };
 
@@ -366,6 +367,56 @@ export const withSettingOverrides = () => (
     }]}
     value={baseContent}
     options={{ debug: true }}
+    onChange={action('change')}
+  />
+);
+
+export const withMergeMultipleLevelsOverrides = () => (
+  <Builder
+    addons={[baseAddon(), {
+      overrides: [
+        {
+          type: 'component',
+          targets: ['image'],
+          fields: [{
+            type: 'image',
+            key: ['url', 'name'],
+            props: {
+              accept: [
+                'image/jpeg', 'image/jpg',
+              ],
+            },
+          }],
+        },
+        {
+          type: 'field',
+          targets: ['image'],
+          render: ImageField,
+          props: {
+            yoo: 'yoo',
+            accept: [
+              'image/jpeg', 'image/jpg', 'image/png',
+            ],
+          },
+        },
+        {
+          type: 'setting',
+          key: 'styles.backgroundImage',
+          targets: ['*'],
+          fields: [],
+          fieldType: 'image',
+          props: {
+            iconOnly: true,
+            className: 'oak-mr-4 oak-relative oak-top-[2px]',
+            accept: [
+              'image/jpeg', 'image/jpg', 'image/png',
+              'image/svg+xml', 'image/gif',
+            ],
+          },
+        }],
+    }]}
+    value={baseContent}
+    options={{ debug: true, overrideStrategy: 'merge' }}
     onChange={action('change')}
   />
 );

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -31,3 +31,9 @@ export const sanitizeHTML = (content: string, opts?: {
     return '';
   }
 };
+
+export const areArraysEqual = (a: any[], b: any[]) =>
+  Array.isArray(a) &&
+  Array.isArray(b) &&
+  a.length === b.length &&
+  a.every((v, i) => v === b[i]);

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -31,9 +31,3 @@ export const sanitizeHTML = (content: string, opts?: {
     return '';
   }
 };
-
-export const areArraysEqual = (a: any[], b: any[]) =>
-  Array.isArray(a) &&
-  Array.isArray(b) &&
-  a.length === b.length &&
-  a.every((v, i) => v === b[i]);


### PR DESCRIPTION
This PR fixes 3 issues with overrides : 
- props from setting overrides were not applied
- field override took the precedence over setting override (now setting override > field override)
- when overriding a component's field that uses multiple keys, the corresponding field was not correctly retrieved so it was duplicated