### PR TITLE
🐛fix(react): refresh catalogue with addons

### DIFF
--- a/packages/react/lib/Catalogue/index.tsx
+++ b/packages/react/lib/Catalogue/index.tsx
@@ -163,7 +163,7 @@ const Catalogue = ({
 
   const availableGroups = useMemo(() => (
     builder.getAvailableComponents()
-  ), [builder]);
+  ), [builder, addons]);
 
   const groups = useMemo(() => (
     availableGroups

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -1,10 +1,12 @@
-import type {
-  AddonObject,
-  ComponentSettingsFieldObject,
-  ElementObject,
+import {
+  stylingSettingsFields,
+  type AddonObject,
+  type ComponentSettingsFieldObject,
+  type ElementObject,
 } from '@oakjs/core';
 import { type FormEvent, useEffect, useRef, useState } from 'react';
 import { action } from '@storybook/addon-actions';
+import { Button } from '@junipero/react';
 
 import Builder, { type BuilderRef } from './Builder';
 import { baseAddon } from './addons';
@@ -650,5 +652,47 @@ export const withFunctionAsDefault = () => {
         options={{ debug: true }}
       />
     </div>
+  );
+};
+
+export const withExtendedSettings = () => (
+  <Builder
+    addons={[
+      baseAddon(),
+      {
+        settings: stylingSettingsFields('styles.checked'),
+      },
+    ]
+
+    }
+    value={baseContent}
+    options={{ debug: true }}
+    onChange={action('change')}
+  />
+);
+
+export const withCatalogueUpdate = () => {
+  const [addons, setAddons] = useState([]);
+
+  const updateAddons = () => {
+    if (addons.length) {
+      setAddons([]);
+    } else {
+      setAddons([baseAddon()]);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={updateAddons}>
+        Update Addons
+      </Button>
+      <Builder
+        addons={addons}
+        value={baseContent}
+        options={{ debug: true }}
+        onChange={action('change')}
+      />
+    </>
   );
 };


### PR DESCRIPTION
force available groups to be refreshed if addons chenge, not only the builder itself

w/ @dackmin 