### PR TITLE
🐛fix: component override on setting

### DIFF
--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -116,7 +116,7 @@ export declare interface ComponentSettingsFieldOptionObject {
 export declare interface ComponentSettingsFieldObject {
   name?: string;
   priority?: number;
-  type?: string;
+  type: string | null;
   key?: string | string[];
   tab?: string;
   id?: string;

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -116,7 +116,7 @@ export declare interface ComponentSettingsFieldOptionObject {
 export declare interface ComponentSettingsFieldObject {
   name?: string;
   priority?: number;
-  type: string;
+  type?: string;
   key?: string | string[];
   tab?: string;
   id?: string;

--- a/packages/react/lib/Editable/Setting.tsx
+++ b/packages/react/lib/Editable/Setting.tsx
@@ -54,12 +54,20 @@ const Setting = ({
     builder.getOverride('setting', element.type, { setting }) as SettingOverride
   ), [element, setting]);
 
+  const componentOverrides = useMemo<ComponentSettingsFieldObject>(() => (
+    builder.getOverride('component', element.type, {
+      output: 'field', setting,
+    }) as ComponentSettingsFieldObject
+  ), [element, setting]);
+
   const hasSubfields = useMemo(() => (
     Array.isArray(override?.fields || setting.fields) &&
     (override?.fields || setting.fields).length > 0
   ), [setting, override]);
 
-  const condition = override?.condition || setting.condition;
+  const condition = override?.condition ||
+    componentOverrides?.condition ||
+    setting.condition;
 
   if (
     condition &&

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -715,9 +715,11 @@ export const withRemovingField = () => {
             targets: ['button', 'clickable'],
             fields: [{
               key: 'url',
+              type: null,
               condition: (element: ElementObject) => true,
             }, {
               key: 'target',
+              type: null,
               condition: (element: ElementObject) => false,
             }],
           }],

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -696,3 +696,34 @@ export const withCatalogueUpdate = () => {
     </>
   );
 };
+
+export const withRemovingField = () => {
+  return (
+    <div>
+      <Builder
+        editableType="modal"
+        value={[{
+          type: 'clickable',
+          action: 'link',
+          url: '',
+          content: [],
+          id: 'eb1c798b-1dc7-4968-95d9-e4faf0e38bd6',
+        }]}
+        addons={[baseAddon(), {
+          overrides: [{
+            type: 'component',
+            targets: ['button', 'clickable'],
+            fields: [{
+              key: 'url',
+              condition: (element: ElementObject) => true,
+            }, {
+              key: 'target',
+              condition: (element: ElementObject) => false,
+            }],
+          }],
+        }]}
+        options={{ debug: true }}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
On `Editable` display, the `Setting` component uses overrides `condition` function to know whether it ghas to display component, or not. And Call `Field` component if its truthy to display Field component, that reuse some overrides to know which field as to be displayed if a field has to. But, as the `Setting` was not using `ComponentOverrides` and only `SettingOverrides` it led that if a `ComponentOverride` wants to hide a field, it can not hide the title of it. 

This fix this behavior