### PR TITLE
🐛 fix: missing field props from setting addon

### DIFF
--- a/packages/react/lib/Editable/Field.tsx
+++ b/packages/react/lib/Editable/Field.tsx
@@ -75,6 +75,7 @@ const Field = ({
       ? onCustomChange.bind(null, setting.key, overrides.field)
       : onChange.bind(null, setting.key),
     ...field?.props,
+    ...setting?.props,
     ...(overrides.field as FieldOverride)?.props,
     ...(overrides.settings as FieldOverride)?.props,
   };

--- a/packages/react/lib/index.stories.tsx
+++ b/packages/react/lib/index.stories.tsx
@@ -624,6 +624,10 @@ export const withSharedSettings = () => (
           { title: 'Wrap', value: 'wrap' },
           { title: 'Wrap Reverse', value: 'wrap-reverse' },
         ],
+        props: {
+          clearable: true,
+          searchable: false,
+        },
         condition: (element: ElementObject) => element.type === 'row',
         default: 'nowrap',
       }],


### PR DESCRIPTION
Some fields like `SelectField` have default props like `clearable={false}` that can be replaced using a field addon `props` property, or overrides, but somehow the `setting` addon `props` property was not among those 🤷‍♂️ 